### PR TITLE
Fix copy forward register to include externally-entered forwarded letters

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/LetterController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/LetterController.java
@@ -1727,7 +1727,70 @@ public class LetterController implements Serializable {
     }
 
     public void fillForwardCopyActions() {
-        documentHistories = findDocumentHistories(fromDate, toDate, HistoryType.Letter_Copy_or_Forward, webUserController.getLoggedInstitution(), webUserCopy);
+        Institution loggedInstitution = webUserController.getLoggedInstitution();
+        List<WebUser> usersForMyInstitute = webUserController.getUsersForMyInstitute();
+
+        Map m = new HashMap();
+        // Include letters entered by own institution OR forwarded by own institution
+        String j = "select distinct h "
+                + " from DocumentHistory h "
+                + " where h.retired=false "
+                + " and h.historyType =:ht "
+                + " and (h.document.institution=:i or h.fromInstitution=:i) ";
+        if (webUserCopy != null) {
+            if (webUserCopy instanceof WebUser) {
+                j += " and h.toUser=:u ";
+                m.put("u", webUserCopy);
+            } else if (webUserCopy instanceof Institution) {
+                j += " and h.toInstitution=:ti ";
+                m.put("ti", webUserCopy);
+            }
+        }
+        j += " and h.createdAt between :fd and :td "
+                + " order by h.id";
+        m.put("i", loggedInstitution);
+        m.put("ht", HistoryType.Letter_Copy_or_Forward);
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+
+        documentHistories = documentHxFacade.findByJpql(j, m, TemporalType.TIMESTAMP);
+
+        if (documentHistories == null) {
+            documentHistories = new ArrayList<>();
+        }
+
+        // Also pick up forwards done by users of this institution where fromInstitution was not set
+        if (usersForMyInstitute != null && !usersForMyInstitute.isEmpty()) {
+            m = new HashMap();
+            j = "select h "
+                    + " from DocumentHistory h "
+                    + " where h.retired=false "
+                    + " and h.historyType =:ht "
+                    + " and h.fromUser in :us "
+                    + " and h.fromInstitution is null "
+                    + " and h.document.institution !=:i ";
+            if (webUserCopy != null) {
+                if (webUserCopy instanceof WebUser) {
+                    j += " and h.toUser=:u ";
+                    m.put("u", webUserCopy);
+                } else if (webUserCopy instanceof Institution) {
+                    j += " and h.toInstitution=:ti ";
+                    m.put("ti", webUserCopy);
+                }
+            }
+            j += " and h.createdAt between :fd and :td "
+                    + " order by h.id";
+            m.put("us", usersForMyInstitute);
+            m.put("i", loggedInstitution);
+            m.put("ht", HistoryType.Letter_Copy_or_Forward);
+            m.put("fd", fromDate);
+            m.put("td", toDate);
+
+            List<DocumentHistory> additionalHistories = documentHxFacade.findByJpql(j, m, TemporalType.TIMESTAMP);
+            if (additionalHistories != null) {
+                documentHistories.addAll(additionalHistories);
+            }
+        }
     }
 
     public void fillLetterAcceptRegister() {


### PR DESCRIPTION
## Summary

- `letter_copy_forward_register.xhtml` was only listing letters entered by the logged-in institution, missing letters entered by other institutions but forwarded by ours
- Updated `fillForwardCopyActions()` to query `h.fromInstitution = loggedInstitution` in addition to `h.document.institution = loggedInstitution` using a `DISTINCT` OR condition
- Added a second query to catch the edge case where `fromInstitution` is null but the forwarding user belongs to the logged institution (mirrors the pattern used in `fillCopyForwardsSentByMyInstitution()`)

## Test plan

- [ ] Log in as a user at Institution A
- [ ] Add a letter from an external institution (Institution B) via `letter.xhtml`
- [ ] Forward that letter from `letter_view.xhtml` to another user/institution
- [ ] Log in as a user at Institution B, add a letter, and forward it from Institution B's account
- [ ] Open `letter_copy_forward_register.xhtml` as Institution A and confirm both letters appear: the one entered by A and the one entered by B but forwarded by A
- [ ] Confirm the "Sent To" filter still works correctly

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)