### PR TITLE
Fix letter From autocomplete: WAF slowness and second selection failure

### DIFF
--- a/src/main/webapp/document/letter.xhtml
+++ b/src/main/webapp/document/letter.xhtml
@@ -140,11 +140,14 @@
                                                 maxResults="10" inputStyle="color:red;"
                                                 itemLabel="#{insf.displayName}"
                                                 itemValue="#{insf}"
+                                                delay="500"
+                                                minQueryLength="3"
+                                                cache="false"
                                                 >
                                     <p:ajax event="itemSelect"
                                             listener="#{letterController.saveCurrentDocumentAjax}"
                                             process="from"
-                                            update="letterId fromPerson"
+                                            update="letterId fromPerson from"
                                             global="false" ></p:ajax>
 
                                 </p:autoComplete>


### PR DESCRIPTION
## Summary

- Add `delay="500"` and `minQueryLength="3"` to the From autocomplete on `letter.xhtml` — collapses one-per-keystroke AJAX requests into one-per-word-boundary, eliminating the dead-slow behaviour on internet connections where each request pays WAF inspection latency
- Add `cache="false"` to prevent stale client-side suggestion caching between sessions
- Add `from` to the `itemSelect` AJAX `update` list — re-renders the PrimeFaces autocomplete widget after each selection, resetting its JS state and fixing the bug where a second institution search after a first selection returned no dropdown results

## Root causes addressed

**Slowness via WAF:** Default PrimeFaces autocomplete fires on every keystroke (300ms idle). A 15-character search = 15 AJAX POST requests, each inspected by the WAF. `delay` + `minQueryLength` reduce this to 1–2 requests for a typical search.

**Second selection not working:** After `itemSelect` fires and saves, the partial update response changes the JSF ViewState but does not re-render the `from` component. This leaves the PrimeFaces autocomplete JS widget in a stale state where it stops sending further complete-method requests. Adding `from` to the update forces a clean widget re-initialisation after each selection.

## Test plan

- [ ] Open letter.xhtml on an internet connection through WAF
- [ ] Type in the From field — confirm suggestions only appear after 3 characters and feel responsive
- [ ] Select an institution — confirm letter saves and `letterId` updates
- [ ] Clear some text and type a different search term — confirm dropdown appears and a new selection can be made
- [ ] Verify LAN behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)