### PR TITLE
Issue #88: API Foundation — ApplicationConfig + /api/* routing + Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,13 @@
             <artifactId>fusionauth-jwt</artifactId>
             <version>5.3.0</version>
         </dependency>
+
+        <!-- Jackson JAX-RS JSON provider for the /api/* REST layer -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>2.15.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/lk/gov/health/phsp/ws/common/ApplicationConfig.java
+++ b/src/main/java/lk/gov/health/phsp/ws/common/ApplicationConfig.java
@@ -1,0 +1,35 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.common;
+
+import java.util.Set;
+import javax.ws.rs.core.Application;
+
+/**
+ * JAX-RS application entry point. Registers the Jackson JSON provider and all
+ * REST resource classes under the /api/* path.
+ */
+@javax.ws.rs.ApplicationPath("api")
+public class ApplicationConfig extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> resources = new java.util.HashSet<>();
+        try {
+            Class<?> jacksonProvider = Class.forName("com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider");
+            resources.add(jacksonProvider);
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException("Jackson JSON provider not found", ex);
+        }
+        addRestResourceClasses(resources);
+        return resources;
+    }
+
+    private void addRestResourceClasses(Set<Class<?>> resources) {
+        resources.add(lk.gov.health.phsp.ws.common.CorsResponseFilter.class);
+    }
+
+}

--- a/src/main/java/lk/gov/health/phsp/ws/common/CorsResponseFilter.java
+++ b/src/main/java/lk/gov/health/phsp/ws/common/CorsResponseFilter.java
@@ -1,0 +1,25 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.common;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class CorsResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        responseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
+        responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        responseContext.getHeaders().add("Access-Control-Allow-Headers", "Content-Type, Api-Key, Authorization");
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds `ApplicationConfig` extending `javax.ws.rs.core.Application` with `@ApplicationPath("api")`, registering the new REST layer at `/api/*`
- Adds `CorsResponseFilter` as a JAX-RS `@Provider` for CORS headers on `/api/*` responses
- Adds `jackson-jaxrs-json-provider 2.15.2` to `pom.xml` for Jackson-based JSON serialization
- Legacy `/data/*` endpoint and `CorsFilter` servlet filter are untouched

## Test plan
- [ ] Deploy and verify `GET /api/` returns 404 (no resources yet) rather than 500
- [ ] Verify `/data/*` endpoints still function
- [ ] Verify response headers include `Access-Control-Allow-Origin: *`

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)