### PR TITLE
Issue #89: ApiKey entity, facade, validation controller

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/ApiKeyController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ApiKeyController.java
@@ -1,0 +1,55 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.bean;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.ejb.EJB;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+import lk.gov.health.phsp.entity.ApiKey;
+import lk.gov.health.phsp.facade.ApiKeyFacade;
+
+@Named
+@ApplicationScoped
+public class ApiKeyController {
+
+    @EJB
+    private ApiKeyFacade apiKeyFacade;
+
+    /**
+     * Validates the given raw key string against active (non-retired) ApiKey records.
+     * Returns the matching ApiKey or null if not found / retired.
+     */
+    public ApiKey validateKey(String rawKey) {
+        if (rawKey == null || rawKey.trim().isEmpty()) {
+            return null;
+        }
+        String jpql = "SELECT k FROM ApiKey k WHERE k.keyValue = :kv AND k.retired = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("kv", rawKey.trim());
+        List<ApiKey> results = apiKeyFacade.findByJpql(jpql, params);
+        return results.isEmpty() ? null : results.get(0);
+    }
+
+    /**
+     * Creates and persists a new ApiKey with a random UUID value.
+     */
+    public ApiKey generateKey(String name, String description) {
+        ApiKey key = new ApiKey();
+        key.setKeyValue(UUID.randomUUID().toString());
+        key.setName(name);
+        key.setDescription(description);
+        key.setCreatedAt(new Date());
+        key.setRetired(false);
+        apiKeyFacade.create(key);
+        return key;
+    }
+
+}

--- a/src/main/java/lk/gov/health/phsp/entity/ApiKey.java
+++ b/src/main/java/lk/gov/health/phsp/entity/ApiKey.java
@@ -1,0 +1,79 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+@Entity
+@Table(name = "api_key")
+public class ApiKey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String keyValue;
+    private String name;
+    private String description;
+    private boolean retired;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser createdBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser retiredBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+
+    private String retireComments;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getKeyValue() { return keyValue; }
+    public void setKeyValue(String keyValue) { this.keyValue = keyValue; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public boolean isRetired() { return retired; }
+    public void setRetired(boolean retired) { this.retired = retired; }
+
+    public WebUser getCreatedBy() { return createdBy; }
+    public void setCreatedBy(WebUser createdBy) { this.createdBy = createdBy; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public WebUser getRetiredBy() { return retiredBy; }
+    public void setRetiredBy(WebUser retiredBy) { this.retiredBy = retiredBy; }
+
+    public Date getRetiredAt() { return retiredAt; }
+    public void setRetiredAt(Date retiredAt) { this.retiredAt = retiredAt; }
+
+    public String getRetireComments() { return retireComments; }
+    public void setRetireComments(String retireComments) { this.retireComments = retireComments; }
+
+}

--- a/src/main/java/lk/gov/health/phsp/facade/ApiKeyFacade.java
+++ b/src/main/java/lk/gov/health/phsp/facade/ApiKeyFacade.java
@@ -1,0 +1,28 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.facade;
+
+import lk.gov.health.phsp.entity.ApiKey;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class ApiKeyFacade extends AbstractFacade<ApiKey> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public ApiKeyFacade() {
+        super(ApiKey.class);
+    }
+
+}


### PR DESCRIPTION
## Summary
- `ApiKey` JPA entity (`api_key` table) with `keyValue`, `name`, `description`, `retired`, `createdBy/At`, `retiredBy/At` fields
- `ApiKeyFacade` — `@Stateless` EJB extending `AbstractFacade<ApiKey>` with `hmisPU` persistence context
- `ApiKeyController` — `@ApplicationScoped` CDI bean with `validateKey(rawKey)` and `generateKey(name, description)` methods

## Test plan
- [ ] Deploy and verify `api_key` table is created by EclipseLink DDL (schema-gen enabled in dev)
- [ ] Confirm `ApiKeyController.generateKey()` persists a UUID key row
- [ ] Confirm `ApiKeyController.validateKey()` returns null for unknown key and entity for known key

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)