### PR TITLE
Issue #90: POST /api/auth/token authentication endpoint

### DIFF
--- a/src/main/java/lk/gov/health/phsp/ws/auth/AuthResource.java
+++ b/src/main/java/lk/gov/health/phsp/ws/auth/AuthResource.java
@@ -1,0 +1,68 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.auth;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lk.gov.health.phsp.bean.ApiKeyController;
+import lk.gov.health.phsp.bean.WebUserApplicationController;
+import lk.gov.health.phsp.entity.ApiKey;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.ws.common.ApiResponseDto;
+import lk.gov.health.phsp.ws.common.AuthRequestDto;
+
+@Path("auth")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AuthResource {
+
+    @Inject
+    private WebUserApplicationController webUserApplicationController;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    /**
+     * POST /api/auth/token
+     * Body: {"username":"...","password":"..."}
+     * Returns: {"status":"success","code":200,"data":{"apiKey":"<uuid>","username":"..."}}
+     */
+    @POST
+    @Path("token")
+    public Response authenticate(AuthRequestDto request) {
+        if (request == null || request.getUsername() == null || request.getPassword() == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(ApiResponseDto.error(400, "username and password are required"))
+                    .build();
+        }
+
+        WebUser user = webUserApplicationController.getWebUser(
+                request.getUsername(), request.getPassword());
+
+        if (user == null) {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .entity(ApiResponseDto.error(401, "Invalid credentials"))
+                    .build();
+        }
+
+        ApiKey key = apiKeyController.generateKey(
+                user.getName(), "API key for " + user.getName());
+
+        Map<String, String> data = new HashMap<>();
+        data.put("apiKey", key.getKeyValue());
+        data.put("username", user.getName());
+
+        return Response.ok(ApiResponseDto.success(data)).build();
+    }
+
+}

--- a/src/main/java/lk/gov/health/phsp/ws/common/ApiResponseDto.java
+++ b/src/main/java/lk/gov/health/phsp/ws/common/ApiResponseDto.java
@@ -1,0 +1,41 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.common;
+
+/**
+ * Standard envelope for all /api/* responses.
+ * Success: {"status":"success","code":200,"data":{...}}
+ * Error:   {"status":"error","code":401,"message":"..."}
+ */
+public class ApiResponseDto {
+
+    private String status;
+    private int code;
+    private Object data;
+    private String message;
+
+    public static ApiResponseDto success(Object data) {
+        ApiResponseDto r = new ApiResponseDto();
+        r.status = "success";
+        r.code = 200;
+        r.data = data;
+        return r;
+    }
+
+    public static ApiResponseDto error(int code, String message) {
+        ApiResponseDto r = new ApiResponseDto();
+        r.status = "error";
+        r.code = code;
+        r.message = message;
+        return r;
+    }
+
+    public String getStatus() { return status; }
+    public int getCode() { return code; }
+    public Object getData() { return data; }
+    public String getMessage() { return message; }
+
+}

--- a/src/main/java/lk/gov/health/phsp/ws/common/ApplicationConfig.java
+++ b/src/main/java/lk/gov/health/phsp/ws/common/ApplicationConfig.java
@@ -29,6 +29,7 @@ public class ApplicationConfig extends Application {
     }
 
     private void addRestResourceClasses(Set<Class<?>> resources) {
+        resources.add(lk.gov.health.phsp.ws.auth.AuthResource.class);
         resources.add(lk.gov.health.phsp.ws.common.CorsResponseFilter.class);
     }
 

--- a/src/main/java/lk/gov/health/phsp/ws/common/AuthRequestDto.java
+++ b/src/main/java/lk/gov/health/phsp/ws/common/AuthRequestDto.java
@@ -1,0 +1,19 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.common;
+
+public class AuthRequestDto {
+
+    private String username;
+    private String password;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+}


### PR DESCRIPTION
## Summary
- `ApiResponseDto` — standard JSON envelope `{status, code, data/message}` with `success()` and `error()` factory methods
- `AuthRequestDto` — POJO for `{username, password}` request body
- `AuthResource` at `@Path("auth")` — `POST /api/auth/token` validates credentials via `WebUserApplicationController.getWebUser()`, then calls `ApiKeyController.generateKey()` and returns the UUID key
- `ApplicationConfig` updated to register `AuthResource`

## Test plan
- [ ] `POST /api/auth/token` with valid credentials returns `{"status":"success","code":200,"data":{"apiKey":"...","username":"..."}}`
- [ ] Invalid credentials return `{"status":"error","code":401,"message":"Invalid credentials"}`
- [ ] Missing body fields return `{"status":"error","code":400,...}`

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)