### PR TITLE
Add user management API (closes #100)

### DIFF
--- a/src/main/java/lk/gov/health/phsp/ws/common/ApplicationConfig.java
+++ b/src/main/java/lk/gov/health/phsp/ws/common/ApplicationConfig.java
@@ -35,6 +35,7 @@ public class ApplicationConfig extends Application {
         resources.add(lk.gov.health.phsp.ws.common.CorsResponseFilter.class);
         resources.add(lk.gov.health.phsp.ws.document.DocumentResource.class);
         resources.add(lk.gov.health.phsp.ws.institution.InstitutionResource.class);
+        resources.add(lk.gov.health.phsp.ws.user.UserResource.class);
     }
 
 }

--- a/src/main/java/lk/gov/health/phsp/ws/user/PasswordUpdateDto.java
+++ b/src/main/java/lk/gov/health/phsp/ws/user/PasswordUpdateDto.java
@@ -1,0 +1,15 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.user;
+
+public class PasswordUpdateDto {
+
+    private String password;
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+}

--- a/src/main/java/lk/gov/health/phsp/ws/user/PrivilegesUpdateDto.java
+++ b/src/main/java/lk/gov/health/phsp/ws/user/PrivilegesUpdateDto.java
@@ -1,0 +1,17 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.user;
+
+import java.util.List;
+
+public class PrivilegesUpdateDto {
+
+    private List<String> privileges;
+
+    public List<String> getPrivileges() { return privileges; }
+    public void setPrivileges(List<String> privileges) { this.privileges = privileges; }
+
+}

--- a/src/main/java/lk/gov/health/phsp/ws/user/UserCreateDto.java
+++ b/src/main/java/lk/gov/health/phsp/ws/user/UserCreateDto.java
@@ -1,0 +1,43 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.user;
+
+public class UserCreateDto {
+
+    private String username;
+    private String password;
+    private String name;
+    private String code;
+    private String email;
+    private String telNo;
+    private String webUserRole;
+    private Long institutionId;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getTelNo() { return telNo; }
+    public void setTelNo(String telNo) { this.telNo = telNo; }
+
+    public String getWebUserRole() { return webUserRole; }
+    public void setWebUserRole(String webUserRole) { this.webUserRole = webUserRole; }
+
+    public Long getInstitutionId() { return institutionId; }
+    public void setInstitutionId(Long institutionId) { this.institutionId = institutionId; }
+
+}

--- a/src/main/java/lk/gov/health/phsp/ws/user/UserResource.java
+++ b/src/main/java/lk/gov/health/phsp/ws/user/UserResource.java
@@ -1,0 +1,518 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.user;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lk.gov.health.phsp.bean.ApiKeyController;
+import lk.gov.health.phsp.entity.ApiKey;
+import lk.gov.health.phsp.entity.Institution;
+import lk.gov.health.phsp.entity.Person;
+import lk.gov.health.phsp.entity.UserPrivilege;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.enums.Privilege;
+import lk.gov.health.phsp.enums.WebUserRole;
+import lk.gov.health.phsp.facade.InstitutionFacade;
+import lk.gov.health.phsp.facade.PersonFacade;
+import lk.gov.health.phsp.facade.UserPrivilegeFacade;
+import lk.gov.health.phsp.facade.WebUserFacade;
+import lk.gov.health.phsp.ws.common.ApiResponseDto;
+import org.jasypt.util.password.BasicPasswordEncryptor;
+
+@Path("users")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class UserResource {
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    @EJB
+    private PersonFacade personFacade;
+
+    @EJB
+    private InstitutionFacade institutionFacade;
+
+    @EJB
+    private UserPrivilegeFacade userPrivilegeFacade;
+
+    /**
+     * GET /api/users?size=50&search=foo
+     * Header: Api-Key: <key>
+     */
+    @GET
+    public Response listUsers(@HeaderParam("Api-Key") String apiKey,
+                              @QueryParam("size") Integer size,
+                              @QueryParam("search") String search) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+
+        int pageSize = (size != null && size > 0 && size <= 500) ? size : 100;
+
+        String jpql = "SELECT u FROM WebUser u WHERE u.retired = false";
+        Map<String, Object> params = new HashMap<>();
+        if (search != null && !search.trim().isEmpty()) {
+            jpql += " AND (lower(u.name) LIKE :q OR lower(u.person.name) LIKE :q)";
+            params.put("q", "%" + search.trim().toLowerCase() + "%");
+        }
+        jpql += " ORDER BY u.name";
+
+        List<WebUser> users = webUserFacade.findByJpql(jpql, params, pageSize);
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (WebUser u : users) {
+            result.add(toMap(u));
+        }
+        return Response.ok(ApiResponseDto.success(result)).build();
+    }
+
+    /**
+     * GET /api/users/{id}
+     */
+    @GET
+    @Path("{id}")
+    public Response getUser(@HeaderParam("Api-Key") String apiKey,
+                            @PathParam("id") Long id) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+
+        WebUser user = webUserFacade.find(id);
+        if (user == null || user.isRetired()) {
+            return notFound("User not found");
+        }
+        return Response.ok(ApiResponseDto.success(toMap(user))).build();
+    }
+
+    /**
+     * POST /api/users
+     * Body: {username, password, name, code?, email?, telNo?, webUserRole, institutionId}
+     *
+     * Creates a new user and auto-grants the role's default privileges. For
+     * Institutional_Administrator this includes the institution-admin
+     * privileges PLUS the full institution-level operating privileges
+     * (matches WebUserController.getInitialPrivileges fallthrough).
+     */
+    @POST
+    public Response createUser(@HeaderParam("Api-Key") String apiKey,
+                               UserCreateDto dto) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+
+        if (dto == null) {
+            return badRequest("Request body is required");
+        }
+        if (isBlank(dto.getUsername())) {
+            return badRequest("username is required");
+        }
+        if (isBlank(dto.getPassword())) {
+            return badRequest("password is required");
+        }
+        if (isBlank(dto.getName())) {
+            return badRequest("name is required");
+        }
+        if (isBlank(dto.getWebUserRole())) {
+            return badRequest("webUserRole is required");
+        }
+        WebUserRole role;
+        try {
+            role = WebUserRole.valueOf(dto.getWebUserRole().trim());
+        } catch (IllegalArgumentException e) {
+            return badRequest("Unknown webUserRole: " + dto.getWebUserRole());
+        }
+        if (usernameExists(dto.getUsername().trim())) {
+            return Response.status(Response.Status.CONFLICT)
+                    .entity(ApiResponseDto.error(409, "Username already exists"))
+                    .build();
+        }
+
+        Institution institution = null;
+        if (dto.getInstitutionId() != null) {
+            institution = institutionFacade.find(dto.getInstitutionId());
+            if (institution == null) {
+                return badRequest("Unknown institutionId: " + dto.getInstitutionId());
+            }
+        }
+
+        Person person = new Person();
+        person.setName(dto.getName().trim());
+        if (!isBlank(dto.getCode())) {
+            person.setCode(dto.getCode().trim());
+        }
+        personFacade.create(person);
+
+        WebUser user = new WebUser();
+        user.setName(dto.getUsername().trim().toLowerCase());
+        user.setPerson(person);
+        user.setEmail(dto.getEmail());
+        user.setTelNo(dto.getTelNo());
+        user.setWebUserRole(role);
+        user.setInstitution(institution);
+        user.setWebUserPassword(new BasicPasswordEncryptor().encryptPassword(dto.getPassword()));
+        user.setCreatedAt(new Date());
+        user.setRetired(false);
+        webUserFacade.create(user);
+
+        grantPrivileges(user, defaultPrivilegesForRole(role));
+
+        return Response.status(Response.Status.CREATED)
+                .entity(ApiResponseDto.success(toMap(user)))
+                .build();
+    }
+
+    /**
+     * PUT /api/users/{id}
+     * Body: any of {name, code, email, telNo, webUserRole, institutionId}
+     */
+    @PUT
+    @Path("{id}")
+    public Response updateUser(@HeaderParam("Api-Key") String apiKey,
+                               @PathParam("id") Long id,
+                               UserUpdateDto dto) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+        WebUser user = webUserFacade.find(id);
+        if (user == null || user.isRetired()) {
+            return notFound("User not found");
+        }
+        if (dto == null) {
+            return badRequest("Request body is required");
+        }
+
+        if (!isBlank(dto.getName())) {
+            user.getPerson().setName(dto.getName().trim());
+        }
+        if (!isBlank(dto.getCode())) {
+            user.getPerson().setCode(dto.getCode().trim());
+        }
+        if (dto.getEmail() != null) {
+            user.setEmail(dto.getEmail());
+        }
+        if (dto.getTelNo() != null) {
+            user.setTelNo(dto.getTelNo());
+        }
+        if (!isBlank(dto.getWebUserRole())) {
+            try {
+                user.setWebUserRole(WebUserRole.valueOf(dto.getWebUserRole().trim()));
+            } catch (IllegalArgumentException e) {
+                return badRequest("Unknown webUserRole: " + dto.getWebUserRole());
+            }
+        }
+        if (dto.getInstitutionId() != null) {
+            Institution institution = institutionFacade.find(dto.getInstitutionId());
+            if (institution == null) {
+                return badRequest("Unknown institutionId: " + dto.getInstitutionId());
+            }
+            user.setInstitution(institution);
+        }
+        user.setLastEditeAt(new Date());
+
+        if (user.getPerson() != null && user.getPerson().getId() != null) {
+            personFacade.edit(user.getPerson());
+        }
+        webUserFacade.edit(user);
+
+        return Response.ok(ApiResponseDto.success(toMap(user))).build();
+    }
+
+    /**
+     * PUT /api/users/{id}/password
+     * Body: {"password":"..."}
+     */
+    @PUT
+    @Path("{id}/password")
+    public Response updatePassword(@HeaderParam("Api-Key") String apiKey,
+                                   @PathParam("id") Long id,
+                                   PasswordUpdateDto dto) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+        WebUser user = webUserFacade.find(id);
+        if (user == null || user.isRetired()) {
+            return notFound("User not found");
+        }
+        if (dto == null || isBlank(dto.getPassword())) {
+            return badRequest("password is required");
+        }
+        user.setWebUserPassword(new BasicPasswordEncryptor().encryptPassword(dto.getPassword()));
+        user.setLastEditeAt(new Date());
+        webUserFacade.edit(user);
+        return Response.ok(ApiResponseDto.success(toMap(user))).build();
+    }
+
+    /**
+     * GET /api/users/{id}/privileges
+     */
+    @GET
+    @Path("{id}/privileges")
+    public Response getPrivileges(@HeaderParam("Api-Key") String apiKey,
+                                  @PathParam("id") Long id) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+        WebUser user = webUserFacade.find(id);
+        if (user == null || user.isRetired()) {
+            return notFound("User not found");
+        }
+        List<String> names = new ArrayList<>();
+        for (UserPrivilege up : activePrivileges(user)) {
+            if (up.getPrivilege() != null) {
+                names.add(up.getPrivilege().name());
+            }
+        }
+        Map<String, Object> data = new HashMap<>();
+        data.put("userId", user.getId());
+        data.put("username", user.getName());
+        data.put("privileges", names);
+        return Response.ok(ApiResponseDto.success(data)).build();
+    }
+
+    /**
+     * PUT /api/users/{id}/privileges
+     * Body: {"privileges":["Manage_Users","Add_File", ...]}
+     *
+     * Replaces the user's privilege set: missing items are retired, new
+     * items are granted (or un-retired if a retired row already exists).
+     */
+    @PUT
+    @Path("{id}/privileges")
+    public Response replacePrivileges(@HeaderParam("Api-Key") String apiKey,
+                                      @PathParam("id") Long id,
+                                      PrivilegesUpdateDto dto) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+        WebUser user = webUserFacade.find(id);
+        if (user == null || user.isRetired()) {
+            return notFound("User not found");
+        }
+        if (dto == null || dto.getPrivileges() == null) {
+            return badRequest("privileges array is required");
+        }
+
+        Set<Privilege> requested = new HashSet<>();
+        for (String name : dto.getPrivileges()) {
+            if (name == null || name.trim().isEmpty()) {
+                continue;
+            }
+            try {
+                requested.add(Privilege.valueOf(name.trim()));
+            } catch (IllegalArgumentException e) {
+                return badRequest("Unknown privilege: " + name);
+            }
+        }
+
+        List<UserPrivilege> existing = activePrivileges(user);
+        Set<Privilege> existingSet = new HashSet<>();
+        for (UserPrivilege up : existing) {
+            if (up.getPrivilege() != null) {
+                existingSet.add(up.getPrivilege());
+            }
+        }
+
+        for (Privilege p : requested) {
+            if (!existingSet.contains(p)) {
+                grantPrivilege(user, p);
+            }
+        }
+        for (UserPrivilege up : existing) {
+            if (up.getPrivilege() != null && !requested.contains(up.getPrivilege())) {
+                up.setRetired(true);
+                up.setRetiredAt(new Date());
+                userPrivilegeFacade.edit(up);
+            }
+        }
+
+        return getPrivileges(apiKey, id);
+    }
+
+    /**
+     * DELETE /api/users/{id} — soft delete (retired=true).
+     */
+    @DELETE
+    @Path("{id}")
+    public Response deleteUser(@HeaderParam("Api-Key") String apiKey,
+                               @PathParam("id") Long id) {
+        ApiKey key = apiKeyController.validateKey(apiKey);
+        if (key == null) {
+            return unauthorized();
+        }
+        WebUser user = webUserFacade.find(id);
+        if (user == null || user.isRetired()) {
+            return notFound("User not found");
+        }
+        user.setRetired(true);
+        user.setRetiredAt(new Date());
+        webUserFacade.edit(user);
+        return Response.ok(ApiResponseDto.success(toMap(user))).build();
+    }
+
+    private boolean usernameExists(String username) {
+        String jpql = "SELECT u FROM WebUser u WHERE lower(u.name) = :un";
+        Map<String, Object> params = new HashMap<>();
+        params.put("un", username.toLowerCase());
+        return webUserFacade.findFirstByJpql(jpql, params) != null;
+    }
+
+    private List<UserPrivilege> activePrivileges(WebUser user) {
+        String jpql = "SELECT p FROM UserPrivilege p WHERE p.retired = false AND p.webUser = :u";
+        Map<String, Object> params = new HashMap<>();
+        params.put("u", user);
+        return userPrivilegeFacade.findByJpql(jpql, params);
+    }
+
+    private void grantPrivileges(WebUser user, List<Privilege> privileges) {
+        for (Privilege p : privileges) {
+            grantPrivilege(user, p);
+        }
+    }
+
+    private void grantPrivilege(WebUser user, Privilege p) {
+        String jpql = "SELECT up FROM UserPrivilege up WHERE up.webUser = :u AND up.privilege = :p ORDER BY up.id DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("u", user);
+        params.put("p", p);
+        UserPrivilege up = userPrivilegeFacade.findFirstByJpql(jpql, params);
+        if (up == null) {
+            up = new UserPrivilege();
+            up.setWebUser(user);
+            up.setPrivilege(p);
+            up.setCreatedAt(new Date());
+            userPrivilegeFacade.create(up);
+        } else {
+            up.setRetired(false);
+            up.setRetiredAt(null);
+            up.setCreatedAt(new Date());
+            userPrivilegeFacade.edit(up);
+        }
+    }
+
+    /**
+     * Mirrors WebUserController.getInitialPrivileges. Institutional_Administrator
+     * deliberately falls through to also include all the institution-level
+     * operating privileges granted to Institutional_Super_User / Institutional_User.
+     */
+    private List<Privilege> defaultPrivilegesForRole(WebUserRole role) {
+        List<Privilege> ps = new ArrayList<>();
+        if (role == null) {
+            return ps;
+        }
+        switch (role) {
+            case Institutional_Administrator:
+                ps.add(Privilege.Institution_Administration);
+                ps.add(Privilege.Manage_Institution_Users);
+                ps.add(Privilege.Manage_Authorised_Institutions);
+                // fallthrough to also grant the institution operating privileges
+            case Institutional_Super_User:
+            case Institutional_User:
+                ps.addAll(Arrays.asList(
+                        Privilege.File_Management,
+                        Privilege.Institutional_Mail_Management,
+                        Privilege.User,
+                        Privilege.Search_File,
+                        Privilege.Retire_File,
+                        Privilege.Add_Actions_To_Letter,
+                        Privilege.Add_Letter,
+                        Privilege.Assign_Letter,
+                        Privilege.Edit_Letter,
+                        Privilege.Receive_File,
+                        Privilege.Retire_Letter));
+                break;
+            case System_Administrator:
+            case Super_User:
+                ps.add(Privilege.Manage_Users);
+                ps.add(Privilege.System_Administration);
+                break;
+            case User:
+                ps.add(Privilege.Monitoring_and_evaluation);
+                ps.add(Privilege.Monitoring_and_evaluation_reports);
+                ps.add(Privilege.View_aggragate_date);
+                ps.add(Privilege.View_individual_data);
+                ps.add(Privilege.File_Management);
+                ps.add(Privilege.Institutional_Mail_Management);
+                ps.add(Privilege.User);
+                ps.add(Privilege.Add_File);
+                ps.add(Privilege.Search_File);
+                ps.add(Privilege.Retire_File);
+                break;
+            default:
+                break;
+        }
+        return ps;
+    }
+
+    private Map<String, Object> toMap(WebUser u) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("id", u.getId());
+        m.put("username", u.getName());
+        m.put("name", u.getPerson() != null ? u.getPerson().getName() : null);
+        m.put("code", u.getPerson() != null ? u.getPerson().getCode() : null);
+        m.put("email", u.getEmail());
+        m.put("telNo", u.getTelNo());
+        m.put("webUserRole", u.getWebUserRole() != null ? u.getWebUserRole().name() : null);
+        m.put("webUserRoleLabel", u.getWebUserRole() != null ? u.getWebUserRole().getLabel() : null);
+        m.put("institutionId", u.getInstitution() != null ? u.getInstitution().getId() : null);
+        m.put("institutionName", u.getInstitution() != null ? u.getInstitution().getName() : null);
+        m.put("retired", u.isRetired());
+        m.put("createdAt", u.getCreatedAt());
+        return m;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    private static Response unauthorized() {
+        return Response.status(Response.Status.UNAUTHORIZED)
+                .entity(ApiResponseDto.error(401, "Invalid or missing Api-Key"))
+                .build();
+    }
+
+    private static Response notFound(String message) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity(ApiResponseDto.error(404, message))
+                .build();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ApiResponseDto.error(400, message))
+                .build();
+    }
+
+}

--- a/src/main/java/lk/gov/health/phsp/ws/user/UserUpdateDto.java
+++ b/src/main/java/lk/gov/health/phsp/ws/user/UserUpdateDto.java
@@ -1,0 +1,35 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ws.user;
+
+public class UserUpdateDto {
+
+    private String name;
+    private String code;
+    private String email;
+    private String telNo;
+    private String webUserRole;
+    private Long institutionId;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getTelNo() { return telNo; }
+    public void setTelNo(String telNo) { this.telNo = telNo; }
+
+    public String getWebUserRole() { return webUserRole; }
+    public void setWebUserRole(String webUserRole) { this.webUserRole = webUserRole; }
+
+    public Long getInstitutionId() { return institutionId; }
+    public void setInstitutionId(Long institutionId) { this.institutionId = institutionId; }
+
+}


### PR DESCRIPTION
## Summary
Adds `/api/users` REST endpoints that mirror the JSF user-admin pages (`user_new.xhtml`, `user_list.xhtml`, `user_edit.xhtml`, `privileges.xhtml`, `user_password.xhtml`):

| Method | Path | Purpose |
| --- | --- | --- |
| `GET` | `/api/users` | List users (`size`, `search`) |
| `GET` | `/api/users/{id}` | Get one user |
| `POST` | `/api/users` | Create a user — auto-grants role-default privileges |
| `PUT` | `/api/users/{id}` | Edit display name / email / role / institution |
| `PUT` | `/api/users/{id}/password` | Change password |
| `GET` | `/api/users/{id}/privileges` | List a user's active privileges |
| `PUT` | `/api/users/{id}/privileges` | Replace a user's privilege set |
| `DELETE` | `/api/users/{id}` | Soft-delete (sets `retired=true`) |

All endpoints require the `Api-Key` header (same convention as `/api/documents`).

### Institution-administrator auto-grant
Creating a user with `webUserRole = Institutional_Administrator` adds the three admin-specific privileges *and* all institution-level operating privileges (File_Management, Institutional_Mail_Management, Search_File, Retire_File, Add_Letter, Edit_Letter, Assign_Letter, Retire_Letter, Receive_File, Add_Actions_To_Letter, User). This mirrors the deliberate `switch` fallthrough in `WebUserController.getInitialPrivileges`, so a user created via the API has the same privilege set as one created via `user_new.xhtml`.

### Notes for review
- Passwords use the same `BasicPasswordEncryptor` (`org.jasypt.util.password`) as `CommonController.hash()`, so API-created users can log in via the JSF UI immediately.
- `PUT /api/users/{id}/privileges` replicates `WebUserController.updateUserPrivileges()` semantics: missing privileges are retired, new ones are added, previously retired rows are un-retired in place.
- No request/IP-restriction logic on the API side — anyone with a valid API key can manage any user, matching the existing `/api/documents` and `/api/institutions` policy.

## Test plan
- [ ] Generate an API key with `POST /api/auth/token`
- [ ] `POST /api/users` with `webUserRole = Institutional_Administrator` and check `GET /api/users/{id}/privileges` returns the merged 14-item set
- [ ] `POST /api/users` with `webUserRole = User` and check the M&E + file/letter privileges appear
- [ ] Created user can log in to the JSF UI with the password supplied via the API
- [ ] `PUT /api/users/{id}/privileges` retires removed items and adds new ones
- [ ] `PUT /api/users/{id}/password` updates the stored hash; old password no longer works
- [ ] `DELETE /api/users/{id}` sets `retired=true` and the user disappears from `GET /api/users`
- [ ] 401 returned when `Api-Key` header is missing or invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)