### PR TITLE
Add School_Dental_Clinic and Adult_Dental_Clinic types

### DIFF
--- a/src/main/java/lk/gov/health/phsp/enums/InstitutionType.java
+++ b/src/main/java/lk/gov/health/phsp/enums/InstitutionType.java
@@ -42,6 +42,8 @@ public enum InstitutionType {
     Partner("Partner"),
     Private_Sector_Institute("Private Sector Institute"),
     Private_Sector_Labatory("Private Sector Laboratory"),
+    School_Dental_Clinic("School Dental Clinic"),
+    Adult_Dental_Clinic("Adult Dental Clinic"),
     Other("Other"),
     @Deprecated
     Ward_Clinic("Ward Clinic");


### PR DESCRIPTION
## Summary
Adds two `InstitutionType` enum values needed for the PDHS-NWP bulk institution import:

- `School_Dental_Clinic` (`School Dental Clinic`) — matches the CSV's `SDC` code for clinics housed in `Maha Vidyalaya` schools.
- `Adult_Dental_Clinic` (`Adult Dental Clinic`) — matches the CSV's `ADC` code.

No other code touched; this is just an enum extension. Once merged + redeployed I'll run the bulk insert of 281 institutions and create the corresponding `Institutional_Administrator` users.

## Test plan
- [ ] Deploy to local Payara
- [ ] `GET /api/auth/token` still works (smoke test)
- [ ] `POST /api/institutions` with `"institutionType":"School_Dental_Clinic"` succeeds and the response echoes the new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)