### PR TITLE
Remove patient/sample/lab privileges and auto-assign Institution Admin privileges

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/WebUserApplicationController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserApplicationController.java
@@ -93,48 +93,54 @@ public class WebUserApplicationController {
     private void createAllPrivilege() {
         allPrivilegeRoot = new PrivilegeTreeNode("Root", null);
 
-        TreeNode clientManagement = new PrivilegeTreeNode("Patient Management", allPrivilegeRoot, Privilege.File_Management);
-        TreeNode sampleManagement = new PrivilegeTreeNode("Sample Management", allPrivilegeRoot, Privilege.Institutional_Mail_Management);
-        TreeNode labManagement = new PrivilegeTreeNode("Lab Management", allPrivilegeRoot, Privilege.Mail_Branch_Mail_Management);
-        TreeNode user = new PrivilegeTreeNode("User", allPrivilegeRoot, Privilege.Manage_Users);
+        TreeNode fileManagement = new PrivilegeTreeNode("File Management", allPrivilegeRoot, Privilege.File_Management);
+        TreeNode institutionalMailManagement = new PrivilegeTreeNode("Institutional Mail Management", allPrivilegeRoot, Privilege.Institutional_Mail_Management);
+        TreeNode mailBranchMailManagement = new PrivilegeTreeNode("Mail Branch Mail Management", allPrivilegeRoot, Privilege.Mail_Branch_Mail_Management);
         TreeNode institutionAdministration = new PrivilegeTreeNode("Institution Administration", allPrivilegeRoot, Privilege.Institution_Administration);
-        TreeNode me = new PrivilegeTreeNode("Monitoring and Evaluation", allPrivilegeRoot, Privilege.Monitoring_and_evaluation);
         TreeNode systemAdministration = new PrivilegeTreeNode("System Administration", allPrivilegeRoot, Privilege.System_Administration);
+        TreeNode me = new PrivilegeTreeNode("Monitoring and Evaluation", allPrivilegeRoot, Privilege.Monitoring_and_evaluation);
 
-        //Client Management
-        TreeNode add_Client = new PrivilegeTreeNode("Add Cases", clientManagement, Privilege.Add_File);
-        TreeNode add_Tests = new PrivilegeTreeNode("Add Tests", clientManagement, Privilege.Edit_File);
-        TreeNode enter_Results = new PrivilegeTreeNode("Enter Results", clientManagement, Privilege.Receive_Letter);
-        TreeNode search_any_Client_by_IDs = new PrivilegeTreeNode("Search any Client by IDs", clientManagement, Privilege.Search_File);
-        TreeNode search_any_Client_by_Details = new PrivilegeTreeNode("Search any Client by Details", clientManagement, Privilege.Retire_File);
+        //File Management
+        new PrivilegeTreeNode("Add File", fileManagement, Privilege.Add_File);
+        new PrivilegeTreeNode("Edit File", fileManagement, Privilege.Edit_File);
+        new PrivilegeTreeNode("Transfer File", fileManagement, Privilege.Transfer_File);
+        new PrivilegeTreeNode("Receive File", fileManagement, Privilege.Receive_File);
+        new PrivilegeTreeNode("Search File", fileManagement, Privilege.Search_File);
+        new PrivilegeTreeNode("Retire File", fileManagement, Privilege.Retire_File);
 
-        //Lab Management
-        TreeNode receive_samples = new PrivilegeTreeNode("Receive Samples", labManagement, Privilege.Transfer_Letter);
-        TreeNode enter_results_lab = new PrivilegeTreeNode("Enter Results", labManagement, Privilege.Receive_Letter);
-        TreeNode review_Results = new PrivilegeTreeNode("Review Results", labManagement, Privilege.Retire_Letter);
-        TreeNode confirm_results = new PrivilegeTreeNode("Confirm Results", labManagement, Privilege.Search_Letter);
-        TreeNode print_results = new PrivilegeTreeNode("Print Results", labManagement, Privilege.Add_Actions_To_Letter);
-        TreeNode view_orders = new PrivilegeTreeNode("View Orders", labManagement, Privilege.Assign_Letter);
-        TreeNode manage_Lab_Reports = new PrivilegeTreeNode("Lab Reports", labManagement, Privilege.Remove_Actions_To_Letter);
+        //Institutional Mail Management
+        new PrivilegeTreeNode("Add Letter", institutionalMailManagement, Privilege.Add_Letter);
+        new PrivilegeTreeNode("Edit Letter", institutionalMailManagement, Privilege.Edit_Letter);
+        new PrivilegeTreeNode("Assign Letter", institutionalMailManagement, Privilege.Assign_Letter);
+        new PrivilegeTreeNode("Transfer Letter", institutionalMailManagement, Privilege.Transfer_Letter);
+        new PrivilegeTreeNode("Receive Letter", institutionalMailManagement, Privilege.Receive_Letter);
+        new PrivilegeTreeNode("Retire Letter", institutionalMailManagement, Privilege.Retire_Letter);
+        new PrivilegeTreeNode("Search Letter", institutionalMailManagement, Privilege.Search_Letter);
+        new PrivilegeTreeNode("Add Actions", institutionalMailManagement, Privilege.Add_Actions_To_Letter);
+        new PrivilegeTreeNode("Remove Actions", institutionalMailManagement, Privilege.Remove_Actions_To_Letter);
+
+        //Mail Branch Mail Management
+        new PrivilegeTreeNode("Add Letter", mailBranchMailManagement, Privilege.Add_Letter_Postal_Branch);
+        new PrivilegeTreeNode("Edit Letter", mailBranchMailManagement, Privilege.Edit_Letter_Postal_Branch);
+        new PrivilegeTreeNode("Retire Letter", mailBranchMailManagement, Privilege.Retire_Letter_Postal_Branch);
+        new PrivilegeTreeNode("Search Letter", mailBranchMailManagement, Privilege.Search_Letter_Postal_Branch);
 
         //Institution Administration
-        TreeNode manage_Institution_Users = new PrivilegeTreeNode("Manage Institution Users", institutionAdministration, Privilege.Manage_Institution_Users);
-        TreeNode manage_Authorised_Areas = new PrivilegeTreeNode("Manage Authorised Areas", institutionAdministration, Privilege.Manage_Authorised_Areas);
-        TreeNode manage_Authorised_Institutions = new PrivilegeTreeNode("Manage Authorised Institutions", institutionAdministration, Privilege.Manage_Authorised_Institutions);
+        new PrivilegeTreeNode("Manage Institution Users", institutionAdministration, Privilege.Manage_Institution_Users);
+        new PrivilegeTreeNode("Manage Authorised Areas", institutionAdministration, Privilege.Manage_Authorised_Areas);
+        new PrivilegeTreeNode("Manage Authorised Institutions", institutionAdministration, Privilege.Manage_Authorised_Institutions);
 
         //System Administration
-        TreeNode manage_Users = new PrivilegeTreeNode("Manage Users", systemAdministration, Privilege.Manage_Users);
-        TreeNode manage_Metadata = new PrivilegeTreeNode("Manage Metadata", systemAdministration, Privilege.Manage_Metadata);
-        TreeNode manage_Area = new PrivilegeTreeNode("Manage Area", systemAdministration, Privilege.Manage_Area);
-        TreeNode manage_Institutions = new PrivilegeTreeNode("Manage Institutions", systemAdministration, Privilege.Manage_Institutions);
-        TreeNode manage_Forms = new PrivilegeTreeNode("Manage Forms", systemAdministration, Privilege.Manage_Forms);
+        new PrivilegeTreeNode("Manage Users", systemAdministration, Privilege.Manage_Users);
+        new PrivilegeTreeNode("Manage Metadata", systemAdministration, Privilege.Manage_Metadata);
+        new PrivilegeTreeNode("Manage Area", systemAdministration, Privilege.Manage_Area);
+        new PrivilegeTreeNode("Manage Institutions", systemAdministration, Privilege.Manage_Institutions);
+        new PrivilegeTreeNode("Manage Forms", systemAdministration, Privilege.Manage_Forms);
 
         //Monitoring and Evaluation
-        TreeNode me_Users = new PrivilegeTreeNode("View Reports", me, Privilege.Monitoring_and_evaluation_reports);
-
-        //Sample Management
-        TreeNode dispatch_samples = new PrivilegeTreeNode("Dispatch Samples", sampleManagement, Privilege.Add_Letter);
-        TreeNode divert_samples = new PrivilegeTreeNode("Divert Samples", sampleManagement, Privilege.Edit_Letter);
+        new PrivilegeTreeNode("View Reports", me, Privilege.Monitoring_and_evaluation_reports);
+        new PrivilegeTreeNode("View Individual Data", me, Privilege.View_individual_data);
+        new PrivilegeTreeNode("View Aggregate Data", me, Privilege.View_aggragate_date);
 
     }
 
@@ -221,39 +227,37 @@ public class WebUserApplicationController {
     private void createHospitalPrivilege() {
         hospitalPrivilegeRoot = new PrivilegeTreeNode("Root", null);
 
-        TreeNode clientManagement = new PrivilegeTreeNode("Patient Management", hospitalPrivilegeRoot, Privilege.File_Management);
-        TreeNode sampleManagement = new PrivilegeTreeNode("Sample Management", hospitalPrivilegeRoot, Privilege.Institutional_Mail_Management);
-        TreeNode labManagement = new PrivilegeTreeNode("Lab Management", hospitalPrivilegeRoot, Privilege.Mail_Branch_Mail_Management);
-        TreeNode user = new PrivilegeTreeNode("User", hospitalPrivilegeRoot, Privilege.Manage_Users);
-        TreeNode institutionAdministration = new PrivilegeTreeNode("System Administration", hospitalPrivilegeRoot, Privilege.Institution_Administration);
+        TreeNode fileManagement = new PrivilegeTreeNode("File Management", hospitalPrivilegeRoot, Privilege.File_Management);
+        TreeNode institutionalMailManagement = new PrivilegeTreeNode("Institutional Mail Management", hospitalPrivilegeRoot, Privilege.Institutional_Mail_Management);
+        TreeNode institutionAdministration = new PrivilegeTreeNode("Institution Administration", hospitalPrivilegeRoot, Privilege.Institution_Administration);
         TreeNode me = new PrivilegeTreeNode("Monitoring and Evaluation", hospitalPrivilegeRoot, Privilege.Monitoring_and_evaluation);
 
-        //Client Management
-        TreeNode add_Client = new PrivilegeTreeNode("Add Cases", clientManagement, Privilege.Add_File);
-        TreeNode add_Tests = new PrivilegeTreeNode("Add Tests", clientManagement, Privilege.Edit_File);
-        TreeNode enter_Results = new PrivilegeTreeNode("Enter Results", clientManagement, Privilege.Receive_Letter);
-        TreeNode search_any_Client_by_IDs = new PrivilegeTreeNode("Search any Client by IDs", clientManagement, Privilege.Search_File);
-        TreeNode search_any_Client_by_Details = new PrivilegeTreeNode("Search any Client by Details", clientManagement, Privilege.Retire_File);
+        //File Management
+        new PrivilegeTreeNode("Add File", fileManagement, Privilege.Add_File);
+        new PrivilegeTreeNode("Edit File", fileManagement, Privilege.Edit_File);
+        new PrivilegeTreeNode("Transfer File", fileManagement, Privilege.Transfer_File);
+        new PrivilegeTreeNode("Receive File", fileManagement, Privilege.Receive_File);
+        new PrivilegeTreeNode("Search File", fileManagement, Privilege.Search_File);
+        new PrivilegeTreeNode("Retire File", fileManagement, Privilege.Retire_File);
 
-        //Lab Management
-        TreeNode receive_samples = new PrivilegeTreeNode("Receive Samples", labManagement, Privilege.Transfer_Letter);
-        TreeNode enter_results_lab = new PrivilegeTreeNode("Enter Results", labManagement, Privilege.Receive_Letter);
-        TreeNode review_Results = new PrivilegeTreeNode("Review Results", labManagement, Privilege.Retire_Letter);
-        TreeNode confirm_results = new PrivilegeTreeNode("Confirm Results", labManagement, Privilege.Search_Letter);
-        TreeNode print_results = new PrivilegeTreeNode("Print Results", labManagement, Privilege.Add_Actions_To_Letter);
-        TreeNode view_orders = new PrivilegeTreeNode("View Orders", labManagement, Privilege.Assign_Letter);
-        TreeNode manage_Lab_Reports = new PrivilegeTreeNode("Lab Reports", labManagement, Privilege.Remove_Actions_To_Letter);
+        //Institutional Mail Management
+        new PrivilegeTreeNode("Add Letter", institutionalMailManagement, Privilege.Add_Letter);
+        new PrivilegeTreeNode("Edit Letter", institutionalMailManagement, Privilege.Edit_Letter);
+        new PrivilegeTreeNode("Assign Letter", institutionalMailManagement, Privilege.Assign_Letter);
+        new PrivilegeTreeNode("Transfer Letter", institutionalMailManagement, Privilege.Transfer_Letter);
+        new PrivilegeTreeNode("Receive Letter", institutionalMailManagement, Privilege.Receive_Letter);
+        new PrivilegeTreeNode("Retire Letter", institutionalMailManagement, Privilege.Retire_Letter);
+        new PrivilegeTreeNode("Search Letter", institutionalMailManagement, Privilege.Search_Letter);
+        new PrivilegeTreeNode("Add Actions", institutionalMailManagement, Privilege.Add_Actions_To_Letter);
+        new PrivilegeTreeNode("Remove Actions", institutionalMailManagement, Privilege.Remove_Actions_To_Letter);
 
         //Institution Administration
-        TreeNode manage_Institution_Users = new PrivilegeTreeNode("Manage Users", institutionAdministration, Privilege.Manage_Institution_Users);
-        TreeNode manage_Authorised_Institutions = new PrivilegeTreeNode("Manage Institutions", institutionAdministration, Privilege.Manage_Authorised_Institutions);
+        new PrivilegeTreeNode("Manage Institution Users", institutionAdministration, Privilege.Manage_Institution_Users);
+        new PrivilegeTreeNode("Manage Authorised Areas", institutionAdministration, Privilege.Manage_Authorised_Areas);
+        new PrivilegeTreeNode("Manage Authorised Institutions", institutionAdministration, Privilege.Manage_Authorised_Institutions);
 
         //Monitoring and Evaluation
-        TreeNode me_Users = new PrivilegeTreeNode("View Reports", me, Privilege.Monitoring_and_evaluation_reports);
-
-        //Sample Management
-        TreeNode dispatch_samples = new PrivilegeTreeNode("Dispatch Samples", sampleManagement, Privilege.Add_Letter);
-        TreeNode divert_samples = new PrivilegeTreeNode("Divert Samples", sampleManagement, Privilege.Edit_Letter);
+        new PrivilegeTreeNode("View Reports", me, Privilege.Monitoring_and_evaluation_reports);
 
     }
 

--- a/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
@@ -1058,6 +1058,7 @@ public class WebUserController implements Serializable {
             case Institutional_Administrator:
                 wups.add(Privilege.Institution_Administration);
                 wups.add(Privilege.Manage_Institution_Users);
+                wups.add(Privilege.Manage_Authorised_Areas);
                 wups.add(Privilege.Manage_Authorised_Institutions);
             case Institutional_Super_User:
             case Institutional_User:


### PR DESCRIPTION
Closes #105

## Summary
- Rebuilt the privilege tree shown on `national/admin/privileges.xhtml`, `webUser/privileges.xhtml`, `national/admin/multiple_user_privilages.xhtml`, and `insAdmin/user_privileges.xhtml`. The legacy "Patient Management", "Sample Management", and "Lab Management" branches (left over from the NCHIS fork — labels even mismatched the underlying `File_Management`/`Institutional_Mail_Management`/`Mail_Branch_Mail_Management` privileges) are gone. They are replaced by the actual DMIS groupings using their correct labels.
- `Privilege.Manage_Authorised_Areas` is now included in the initial privilege set for the `Institutional_Administrator` role, so creating a new user with role "Institution Administrator" on `national/admin/user_new.xhtml` auto-assigns all four institution administration privileges (`Institution_Administration`, `Manage_Institution_Users`, `Manage_Authorised_Areas`, `Manage_Authorised_Institutions`).
- No enum values were removed from `Privilege.java` — the deprecated patient/sample/lab values stay so existing `UserPrivilege` rows persisted with those names continue to load.

## Test plan
- [ ] Build and deploy the app
- [ ] Log in as a system administrator and open `/dmis/app/national/admin/privileges.xhtml` for an existing user — verify the tree shows only File Management, Institutional Mail Management, Mail Branch Mail Management, Institution Administration, System Administration, and Monitoring and Evaluation (no Patient/Sample/Lab branches)
- [ ] Open the same privileges page from the institution admin side (`insAdmin/user_privileges.xhtml`) — verify clean tree
- [ ] Create a new user on `/dmis/app/national/admin/user_new.xhtml` with role "Institution Administrator", then open their privileges and confirm all four institution administration privileges are checked, including Manage Authorised Areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)