### PR TITLE
Letter import (1/6): PDF segmentation & rendering service (PDFBox)

### DIFF
--- a/docs/letter-import-plan.md
+++ b/docs/letter-import-plan.md
@@ -1,0 +1,62 @@
+# Plan: User-keyed Claude letter import (PDF → split → OCR → review → create)
+
+## Goal
+Let users upload a multi-page PDF in which individual letters are separated by
+blank pages. The application temporarily holds the PDF, uses **the logged-in
+user's own Claude API key** to OCR and split it into per-letter segments, renders
+each letter to image(s), and proposes letter metadata (subject, letter date,
+stamp/received date defaulting to today, sending institution/sender — grounded
+against the in-built institution/staff API). The user reviews each proposed
+letter and may **Accept & Create**, **Save edits**, **Discard**, or **Skip**.
+
+## Design decisions (approved)
+- **Split:** PDFBox detects blank separator pages locally and segments the PDF;
+  each segment is sent to Claude (user's key) for OCR + metadata.
+- **Key storage:** dedicated `UserClaudeApiKey` entity, AES-GCM encrypted at
+  rest, one active key per user, masked in UI, never returned to the browser.
+- **Staging:** `LetterImportBatch` + `LetterImportItem` persist the PDF and
+  per-letter proposals; resumable, with a scheduled cleanup job.
+- **Grounding:** Claude is given in-process `institution_search` / `staff_search`
+  tools (the HMIS agentic pattern) so the proposed sender resolves to a real
+  entity; UI autocomplete is the fallback.
+
+## Key facts about the codebase
+- A "letter" is the `Document` entity; managed by session-scoped
+  `LetterController`. Attachments are the `Upload` entity (`baImage` LONGBLOB).
+- An internal REST API already exists (`Api-Key` header): `InstitutionResource`,
+  `UserResource`, `LetterResource`.
+- Java 8 source target. PDF libs present: itext + flying-saucer (neither can
+  rasterize) → add **PDFBox 2.0.x**.
+- HMIS reference: `com.divudi.service.AnthropicApiService` (Stateless EJB, Java
+  `HttpClient`, agentic tool loop, image+document base64 blocks). HMIS uses one
+  app-wide key; DMIS must be per-user instead.
+
+## Issues / PRs (sequential)
+1. **PDF segmentation & rendering service** — add PDFBox; `PdfSplitService`
+   (`detectSegments`, `extractSubPdf`, `renderPagesToPng`).
+2. **Per-user encrypted Claude API key** — `UserClaudeApiKey` entity + facade,
+   `CryptoService` (AES-GCM), `ClaudeApiKeyController`, `claude_api_key.xhtml`
+   under "Manage My API Keys" menu, new privilege.
+3. **AnthropicApiService port + DMIS tools** — port/trim HMIS service into
+   `lk.gov.health.phsp.ejb`; add `institution_search`/`staff_search` tools;
+   `LetterExtractionService.extractFromSegment` → strict-JSON metadata + usage.
+   Open question: confirm runtime JRE (Java 11+ keeps JDK HttpClient; true Java 8
+   → Apache HttpClient).
+4. **Staging entities + async orchestration** — `LetterImportBatch` /
+   `LetterImportItem` + facades; `LetterImportService` (`@Asynchronous`):
+   detect → render + Claude extract → persist items; progress tracking.
+5. **Review wizard UI + create-letter integration** — `LetterImportController`,
+   `letter_import.xhtml` (upload → progress poll → wizard), Accept & Create /
+   Save / Discard / Skip; reuse `LetterController`/`uploadFacade` patterns; menu
+   + privilege.
+6. **Config, cleanup, privileges, docs** — ConfigOptions (model, max pages,
+   blank threshold, DPI, retention days), `@Schedule` cleanup, docs.
+
+PRs land 1 → 2 → 3 → 4 → 5 → 6. Issues 1/2/3 have no cross-deps and may be
+parallelized; 5 depends on 1–4; 3 depends on 2.
+
+## Risks
+- Runtime JRE drives the HTTP-client choice (Issue 3).
+- Cost is on the user's own key; mitigated by per-request page caps + cheaper
+  default model.
+- Security: AES-GCM at rest, masked display, key excluded from DTOs/logs.

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,15 @@
             <type>jar</type>
         </dependency>
 
+        <!-- PDFBox 2.0.x: Java 8 compatible. Used to detect blank separator
+             pages, split a multi-letter PDF into per-letter sub-PDFs, and
+             rasterize pages to PNG for the letter-import feature. -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.31</version>
+        </dependency>
+
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.core</artifactId>

--- a/src/main/java/lk/gov/health/phsp/ejb/PdfSplitService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/PdfSplitService.java
@@ -1,0 +1,173 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ejb.Stateless;
+import javax.imageio.ImageIO;
+import lk.gov.health.phsp.pojcs.PageRange;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+/**
+ * Local (no external service) PDF processing for the letter-import feature.
+ *
+ * <p>Users upload a single PDF in which individual letters are separated by
+ * blank pages. This service detects those blank separator pages, groups the
+ * remaining pages into per-letter {@link PageRange} segments, extracts a
+ * per-letter sub-PDF (to hand to Claude as a {@code document} block), and
+ * rasterizes pages to PNG (to store as letter attachments).</p>
+ *
+ * <p>Blank detection is done by rasterizing each page at a low DPI and
+ * measuring the fraction of "ink" (dark) pixels. This works for scanned,
+ * image-only PDFs that have no text layer, which a text-based check would
+ * miss.</p>
+ */
+@Stateless
+public class PdfSplitService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** DPI used for the cheap blank-detection render. */
+    private static final int DETECTION_DPI = 50;
+
+    /** Luminance (0-255) below which a pixel is counted as ink. */
+    private static final int INK_LUMINANCE_THRESHOLD = 128;
+
+    /**
+     * Default maximum fraction of ink pixels for a page to count as blank.
+     * A speckle-free blank page is ~0; scanned blanks carry a little noise,
+     * so a small non-zero default is used.
+     */
+    public static final double DEFAULT_BLANK_THRESHOLD = 0.005;
+
+    /** Default DPI for the stored letter image render. */
+    public static final int DEFAULT_RENDER_DPI = 150;
+
+    /**
+     * Detects per-letter page ranges using the default blank threshold.
+     */
+    public List<PageRange> detectSegments(byte[] pdfBytes) throws IOException {
+        return detectSegments(pdfBytes, DEFAULT_BLANK_THRESHOLD);
+    }
+
+    /**
+     * Detects per-letter page ranges by treating blank pages as separators.
+     *
+     * <p>Leading, trailing, and consecutive blank pages are ignored; each run
+     * of consecutive non-blank pages becomes one {@link PageRange}. If no blank
+     * pages are found, the whole document is returned as a single range.</p>
+     *
+     * @param pdfBytes       the uploaded PDF
+     * @param blankThreshold maximum ink fraction (0..1) for a page to be blank
+     * @return ordered, non-overlapping letter ranges (possibly empty)
+     */
+    public List<PageRange> detectSegments(byte[] pdfBytes, double blankThreshold) throws IOException {
+        List<PageRange> ranges = new ArrayList<>();
+        if (pdfBytes == null || pdfBytes.length == 0) {
+            return ranges;
+        }
+        try (PDDocument document = PDDocument.load(new ByteArrayInputStream(pdfBytes))) {
+            int pageCount = document.getNumberOfPages();
+            PDFRenderer renderer = new PDFRenderer(document);
+
+            int segmentStart = -1;
+            for (int i = 0; i < pageCount; i++) {
+                boolean blank = isPageBlank(renderer, i, blankThreshold);
+                if (blank) {
+                    if (segmentStart >= 0) {
+                        ranges.add(new PageRange(segmentStart, i - 1));
+                        segmentStart = -1;
+                    }
+                } else if (segmentStart < 0) {
+                    segmentStart = i;
+                }
+            }
+            if (segmentStart >= 0) {
+                ranges.add(new PageRange(segmentStart, pageCount - 1));
+            }
+        }
+        return ranges;
+    }
+
+    /**
+     * Renders a single page to grayscale at low DPI and returns the fraction of
+     * dark (ink) pixels, comparing it against {@code blankThreshold}.
+     */
+    private boolean isPageBlank(PDFRenderer renderer, int pageIndex, double blankThreshold) throws IOException {
+        BufferedImage image = renderer.renderImageWithDPI(pageIndex, DETECTION_DPI, ImageType.GRAY);
+        int width = image.getWidth();
+        int height = image.getHeight();
+        long totalPixels = (long) width * height;
+        if (totalPixels == 0) {
+            return true;
+        }
+        long inkPixels = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                // GRAY image: the low byte of the RGB int is the luminance.
+                int luminance = image.getRGB(x, y) & 0xFF;
+                if (luminance < INK_LUMINANCE_THRESHOLD) {
+                    inkPixels++;
+                }
+            }
+        }
+        double inkFraction = (double) inkPixels / (double) totalPixels;
+        return inkFraction <= blankThreshold;
+    }
+
+    /**
+     * Extracts the given inclusive, zero-based page range into a standalone PDF.
+     *
+     * @return the bytes of a new PDF containing only those pages
+     */
+    public byte[] extractSubPdf(byte[] pdfBytes, int startPage, int endPage) throws IOException {
+        try (PDDocument source = PDDocument.load(new ByteArrayInputStream(pdfBytes));
+             PDDocument target = new PDDocument()) {
+            int pageCount = source.getNumberOfPages();
+            int from = Math.max(0, startPage);
+            int to = Math.min(pageCount - 1, endPage);
+            for (int i = from; i <= to; i++) {
+                PDPage imported = target.importPage(source.getPage(i));
+                // importPage clones structure; nothing else required.
+                if (imported == null) {
+                    throw new IOException("Failed to import page " + i);
+                }
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            target.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    /**
+     * Rasterizes a single page to PNG at the default render DPI.
+     */
+    public byte[] renderPageToPng(byte[] pdfBytes, int pageIndex) throws IOException {
+        return renderPageToPng(pdfBytes, pageIndex, DEFAULT_RENDER_DPI);
+    }
+
+    /**
+     * Rasterizes a single zero-based page to PNG at the given DPI.
+     */
+    public byte[] renderPageToPng(byte[] pdfBytes, int pageIndex, int dpi) throws IOException {
+        try (PDDocument document = PDDocument.load(new ByteArrayInputStream(pdfBytes))) {
+            PDFRenderer renderer = new PDFRenderer(document);
+            BufferedImage image = renderer.renderImageWithDPI(pageIndex, dpi, ImageType.RGB);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", out);
+            return out.toByteArray();
+        }
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/pojcs/PageRange.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/PageRange.java
@@ -1,0 +1,59 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+
+/**
+ * A contiguous range of pages within a PDF that represents a single letter,
+ * produced by {@code PdfSplitService.detectSegments}.
+ *
+ * <p>Page indices are <strong>zero-based and inclusive</strong>:
+ * {@code start} is the first page of the letter, {@code end} is the last.</p>
+ */
+public class PageRange implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int start;
+    private int end;
+
+    public PageRange() {
+    }
+
+    public PageRange(int start, int end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /** Zero-based index of the first page (inclusive). */
+    public int getStart() {
+        return start;
+    }
+
+    public void setStart(int start) {
+        this.start = start;
+    }
+
+    /** Zero-based index of the last page (inclusive). */
+    public int getEnd() {
+        return end;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    /** Number of pages in this letter (always >= 1 for a valid range). */
+    public int getPageCount() {
+        return (end - start) + 1;
+    }
+
+    @Override
+    public String toString() {
+        return "PageRange{" + start + ".." + end + " (" + getPageCount() + " pages)}";
+    }
+}


### PR DESCRIPTION
Closes #114. Part 1 of the user-keyed Claude letter-import feature (`docs/letter-import-plan.md`).

## What
- **pom.xml**: add PDFBox `2.0.31` (Java 8 compatible).
- **PageRange** (pojcs): zero-based, inclusive per-letter page range.
- **PdfSplitService** (Stateless EJB):
  - `detectSegments(pdf[, threshold])` — groups consecutive non-blank pages into per-letter ranges, treating blank pages as separators. Blank detection rasterizes each page at low DPI (50) and measures ink-pixel fraction, so it works on **scanned, text-less PDFs**.
  - `extractSubPdf(pdf, start, end)` — standalone per-letter PDF for Claude `document` blocks.
  - `renderPageToPng(pdf, page[, dpi])` — rasterize a page for storage as an `Upload`.

## Notes
- Defaults are constants now (blank threshold 0.005, render DPI 150); they become ConfigOptions in PR #6 (#119).
- No wiring/UI yet — pure service, consumed by PR #4 (#117).

## Testing
Build is performed by the maintainer. Logic is self-contained; suggested manual check: feed a multi-letter PDF (letters separated by blank pages) and confirm `detectSegments` returns one range per letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)