### PR TITLE
Letter import (2/6): Per-user encrypted Claude API key + management page

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/ClaudeApiKeyController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ClaudeApiKeyController.java
@@ -1,0 +1,186 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.bean;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lk.gov.health.phsp.bean.util.JsfUtil;
+import lk.gov.health.phsp.ejb.CryptoService;
+import lk.gov.health.phsp.entity.UserClaudeApiKey;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.facade.UserClaudeApiKeyFacade;
+
+/**
+ * Self-service management of the logged-in user's personal Claude API key.
+ *
+ * <p>The raw key is encrypted via {@link CryptoService} before persistence and
+ * is never read back into the page; only a masked hint is shown. Other features
+ * (letter import) obtain the usable key through
+ * {@link #getActiveDecryptedKey(WebUser)}.</p>
+ */
+@Named
+@SessionScoped
+public class ClaudeApiKeyController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private UserClaudeApiKeyFacade userClaudeApiKeyFacade;
+    @EJB
+    private CryptoService cryptoService;
+    @Inject
+    private WebUserController webUserController;
+
+    /** Transient raw key typed by the user; never persisted as-is. */
+    private String rawKeyInput;
+    private String modelOverride;
+    private UserClaudeApiKey activeKey;
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+
+    public String toManageMyClaudeApiKey() {
+        rawKeyInput = null;
+        loadActiveKey();
+        modelOverride = activeKey != null ? activeKey.getModelOverride() : null;
+        return "/change_my_claude_api_key?faces-redirect=true";
+    }
+
+    // -------------------------------------------------------------------------
+    // Actions
+    // -------------------------------------------------------------------------
+
+    public void saveKey() {
+        WebUser user = webUserController.getLoggedUser();
+        if (user == null) {
+            JsfUtil.addErrorMessage("No logged-in user.");
+            return;
+        }
+        if (rawKeyInput == null || rawKeyInput.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please paste your Claude API key.");
+            return;
+        }
+        String raw = rawKeyInput.trim();
+
+        loadActiveKey();
+        if (activeKey != null) {
+            retire(activeKey, "Replaced by a new key", user);
+        }
+
+        UserClaudeApiKey key = new UserClaudeApiKey();
+        key.setOwner(user);
+        key.setEncryptedKey(cryptoService.encrypt(raw));
+        key.setLast4(raw.length() >= 4 ? raw.substring(raw.length() - 4) : raw);
+        key.setModelOverride(modelOverride != null && !modelOverride.trim().isEmpty()
+                ? modelOverride.trim() : null);
+        key.setActive(true);
+        key.setCreatedBy(user);
+        key.setCreatedAt(new Date());
+        userClaudeApiKeyFacade.create(key);
+
+        // Drop the raw value from memory as soon as it is stored.
+        rawKeyInput = null;
+        activeKey = key;
+        JsfUtil.addSuccessMessage("Your Claude API key has been saved securely.");
+    }
+
+    public void removeKey() {
+        WebUser user = webUserController.getLoggedUser();
+        loadActiveKey();
+        if (activeKey == null) {
+            JsfUtil.addErrorMessage("No key to remove.");
+            return;
+        }
+        retire(activeKey, "Removed by user", user);
+        activeKey = null;
+        modelOverride = null;
+        JsfUtil.addSuccessMessage("Your Claude API key has been removed.");
+    }
+
+    private void retire(UserClaudeApiKey key, String comment, WebUser user) {
+        key.setActive(false);
+        key.setRetired(true);
+        key.setRetiredBy(user);
+        key.setRetiredAt(new Date());
+        key.setRetireComments(comment);
+        userClaudeApiKeyFacade.edit(key);
+    }
+
+    // -------------------------------------------------------------------------
+    // Lookup helpers (used here and by the letter-import feature)
+    // -------------------------------------------------------------------------
+
+    private void loadActiveKey() {
+        activeKey = findActiveKey(webUserController.getLoggedUser());
+    }
+
+    public UserClaudeApiKey findActiveKey(WebUser user) {
+        if (user == null) {
+            return null;
+        }
+        String jpql = "SELECT k FROM UserClaudeApiKey k "
+                + "WHERE k.owner = :owner AND k.active = true AND k.retired = false "
+                + "ORDER BY k.id DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("owner", user);
+        List<UserClaudeApiKey> results = userClaudeApiKeyFacade.findByJpql(jpql, params);
+        return results.isEmpty() ? null : results.get(0);
+    }
+
+    /**
+     * Returns the decrypted, usable Claude API key for the given user, or
+     * {@code null} if they have not configured one.
+     */
+    public String getActiveDecryptedKey(WebUser user) {
+        UserClaudeApiKey key = findActiveKey(user);
+        if (key == null || key.getEncryptedKey() == null) {
+            return null;
+        }
+        return cryptoService.decrypt(key.getEncryptedKey());
+    }
+
+    // -------------------------------------------------------------------------
+    // View state
+    // -------------------------------------------------------------------------
+
+    public boolean isKeyConfigured() {
+        if (activeKey == null) {
+            loadActiveKey();
+        }
+        return activeKey != null;
+    }
+
+    public String getMaskedKey() {
+        if (activeKey == null) {
+            loadActiveKey();
+        }
+        if (activeKey == null) {
+            return "Not set";
+        }
+        return "sk-ant-••••••••••••" + (activeKey.getLast4() != null ? activeKey.getLast4() : "");
+    }
+
+    public String getRawKeyInput() { return rawKeyInput; }
+    public void setRawKeyInput(String rawKeyInput) { this.rawKeyInput = rawKeyInput; }
+
+    public String getModelOverride() { return modelOverride; }
+    public void setModelOverride(String modelOverride) { this.modelOverride = modelOverride; }
+
+    public UserClaudeApiKey getActiveKey() {
+        if (activeKey == null) {
+            loadActiveKey();
+        }
+        return activeKey;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/CryptoService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/CryptoService.java
@@ -1,0 +1,79 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import javax.ejb.Stateless;
+import org.jasypt.util.text.StrongTextEncryptor;
+
+/**
+ * Reversible encryption for sensitive secrets that must be recovered later
+ * (currently each user's Claude API key).
+ *
+ * <p>Uses Jasypt's {@link StrongTextEncryptor} (PBE with MD5 and TripleDES) —
+ * the same library the application already uses for its other reversible
+ * encryption, but stronger than the legacy {@code BasicTextEncryptor} used for
+ * non-sensitive values.</p>
+ *
+ * <p>The passphrase is resolved, in order, from the system property
+ * {@code dmis.crypto.secret}, then the environment variable
+ * {@code DMIS_CRYPTO_SECRET}, falling back to a built-in default. Operators
+ * should set one of the former in production so secrets are not recoverable
+ * from a database dump alone.</p>
+ */
+@Stateless
+public class CryptoService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String SYSTEM_PROPERTY = "dmis.crypto.secret";
+    private static final String ENV_VARIABLE = "DMIS_CRYPTO_SECRET";
+    private static final String DEFAULT_SECRET = "dmis-default-secret-change-me";
+
+    private StrongTextEncryptor encryptor;
+
+    private StrongTextEncryptor encryptor() {
+        if (encryptor == null) {
+            StrongTextEncryptor e = new StrongTextEncryptor();
+            e.setPassword(resolveSecret());
+            encryptor = e;
+        }
+        return encryptor;
+    }
+
+    private String resolveSecret() {
+        String secret = System.getProperty(SYSTEM_PROPERTY);
+        if (secret == null || secret.trim().isEmpty()) {
+            secret = System.getenv(ENV_VARIABLE);
+        }
+        if (secret == null || secret.trim().isEmpty()) {
+            secret = DEFAULT_SECRET;
+        }
+        return secret;
+    }
+
+    /**
+     * Encrypts the given clear-text value. Returns {@code null} for a
+     * {@code null} input.
+     */
+    public String encrypt(String clearText) {
+        if (clearText == null) {
+            return null;
+        }
+        return encryptor().encrypt(clearText);
+    }
+
+    /**
+     * Decrypts a value previously produced by {@link #encrypt(String)}. Returns
+     * {@code null} for a {@code null} input.
+     */
+    public String decrypt(String cipherText) {
+        if (cipherText == null) {
+            return null;
+        }
+        return encryptor().decrypt(cipherText);
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/entity/UserClaudeApiKey.java
+++ b/src/main/java/lk/gov/health/phsp/entity/UserClaudeApiKey.java
@@ -1,0 +1,111 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * A user's personal Claude (Anthropic) API key, used by the letter-import
+ * feature so each user is billed on their own key rather than an
+ * application-wide one.
+ *
+ * <p>The raw key is <strong>never</strong> stored in clear text: only the
+ * encrypted form ({@link #encryptedKey}) and a short, non-sensitive hint
+ * ({@link #last4}) for display are persisted. At most one non-retired record
+ * per {@link #owner} should be {@link #active}.</p>
+ */
+@Entity
+@Table(name = "user_claude_api_key")
+public class UserClaudeApiKey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser owner;
+
+    /** Encrypted Claude API key (see CryptoService). Never the raw value. */
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String encryptedKey;
+
+    /** Last 4 characters of the raw key, kept only for masked display. */
+    @Column(length = 8)
+    private String last4;
+
+    /** Optional per-user Claude model override (else the configured default). */
+    private String modelOverride;
+
+    private boolean active;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser createdBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    private boolean retired;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser retiredBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+
+    private String retireComments;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public WebUser getOwner() { return owner; }
+    public void setOwner(WebUser owner) { this.owner = owner; }
+
+    public String getEncryptedKey() { return encryptedKey; }
+    public void setEncryptedKey(String encryptedKey) { this.encryptedKey = encryptedKey; }
+
+    public String getLast4() { return last4; }
+    public void setLast4(String last4) { this.last4 = last4; }
+
+    public String getModelOverride() { return modelOverride; }
+    public void setModelOverride(String modelOverride) { this.modelOverride = modelOverride; }
+
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+
+    public WebUser getCreatedBy() { return createdBy; }
+    public void setCreatedBy(WebUser createdBy) { this.createdBy = createdBy; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public boolean isRetired() { return retired; }
+    public void setRetired(boolean retired) { this.retired = retired; }
+
+    public WebUser getRetiredBy() { return retiredBy; }
+    public void setRetiredBy(WebUser retiredBy) { this.retiredBy = retiredBy; }
+
+    public Date getRetiredAt() { return retiredAt; }
+    public void setRetiredAt(Date retiredAt) { this.retiredAt = retiredAt; }
+
+    public String getRetireComments() { return retireComments; }
+    public void setRetireComments(String retireComments) { this.retireComments = retireComments; }
+
+}

--- a/src/main/java/lk/gov/health/phsp/enums/Privilege.java
+++ b/src/main/java/lk/gov/health/phsp/enums/Privilege.java
@@ -33,6 +33,7 @@ public enum Privilege {
     Search_Letter("Search Letter"),
     Add_Actions_To_Letter("Add Actions"),
     Remove_Actions_To_Letter("Remove Actions"),
+    Import_Letters("Import Letters from PDF"),
     //Mail Branch Mail Management
     Add_Letter_Postal_Branch("Add Letter"),
     Edit_Letter_Postal_Branch("Edit Letter"),

--- a/src/main/java/lk/gov/health/phsp/facade/UserClaudeApiKeyFacade.java
+++ b/src/main/java/lk/gov/health/phsp/facade/UserClaudeApiKeyFacade.java
@@ -1,0 +1,28 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.facade;
+
+import lk.gov.health.phsp.entity.UserClaudeApiKey;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class UserClaudeApiKeyFacade extends AbstractFacade<UserClaudeApiKey> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public UserClaudeApiKeyFacade() {
+        super(UserClaudeApiKey.class);
+    }
+
+}

--- a/src/main/webapp/change_my_claude_api_key.xhtml
+++ b/src/main/webapp/change_my_claude_api_key.xhtml
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <body>
+        <ui:composition template="./template1.xhtml">
+            <ui:define name="content">
+                <h:form>
+                    <p:panelGrid columns="2" columnClasses="alignLeft alignLeft" class="pageCenter bg-white border border-light">
+
+                        <f:facet name="header">
+                            <div class="fs-5 fw-bold my-2">My Claude API Key</div>
+                        </f:facet>
+
+                        <h:outputLabel value="Current Key" class="fs-6 fw-bold" />
+                        <h:outputText value="#{claudeApiKeyController.maskedKey}" />
+
+                        <h:outputLabel value="New Claude API Key" class="fs-6 fw-bold" />
+                        <p:inputText class="form-control" id="rawKey" autocomplete="off"
+                                     value="#{claudeApiKeyController.rawKeyInput}"
+                                     placeholder="sk-ant-..." />
+
+                        <h:outputLabel value="Model (optional)" class="fs-6 fw-bold" />
+                        <p:inputText class="form-control" id="modelOverride" autocomplete="off"
+                                     value="#{claudeApiKeyController.modelOverride}"
+                                     placeholder="leave blank to use the system default" />
+
+                        <p:spacer />
+                        <h:panelGroup>
+                            <h:commandButton class="my-2 me-2 btn btn-success"
+                                             action="#{claudeApiKeyController.saveKey()}"
+                                             value="Save Key" />
+                            <h:commandButton class="my-2 btn btn-outline-danger"
+                                             action="#{claudeApiKeyController.removeKey()}"
+                                             rendered="#{claudeApiKeyController.keyConfigured}"
+                                             value="Remove Key" />
+                        </h:panelGroup>
+                    </p:panelGrid>
+
+                    <div class="pageCenter text-muted small mt-3">
+                        Your key is stored encrypted and is used only to process your own letter
+                        imports. It is never shown again after saving and is billed to your own
+                        Anthropic account. Get a key at
+                        <h:outputLink value="https://console.anthropic.com/settings/keys" target="_blank">
+                            console.anthropic.com</h:outputLink>.
+                    </div>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </body>
+</html>

--- a/src/main/webapp/resources/ezcomp/header.xhtml
+++ b/src/main/webapp/resources/ezcomp/header.xhtml
@@ -50,6 +50,9 @@
                                         <h:commandButton action="#{webUserController.toChangeMyUsername()}"
                                                          class="dropdown-item" value="Change My Username">
                                         </h:commandButton>
+                                        <h:commandButton action="#{claudeApiKeyController.toManageMyClaudeApiKey()}"
+                                                         class="dropdown-item" value="My Claude API Key">
+                                        </h:commandButton>
                                         <h:commandButton action="#{webUserController.toChangeLoggedInstitution()}"
                                                          class="dropdown-item" value="Change Logged Institute">
                                         </h:commandButton>


### PR DESCRIPTION
Closes #115. Part 2 of the user-keyed Claude letter-import feature (`docs/letter-import-plan.md`).

## What
- **UserClaudeApiKey** entity + **UserClaudeApiKeyFacade** — encrypted key, `last4` hint for display, optional `modelOverride`, one active key per user, audit/retire fields.
- **CryptoService** (Stateless EJB) — Jasypt `StrongTextEncryptor` (PBE/MD5/TripleDES, stronger than the legacy `BasicTextEncryptor`). Passphrase from `dmis.crypto.secret` system property → `DMIS_CRYPTO_SECRET` env → built-in default.
- **ClaudeApiKeyController** (session) — save/replace/remove; masked display; `getActiveDecryptedKey(WebUser)` for PRs #3/#4.
- **change_my_claude_api_key.xhtml** + a **My Claude API Key** item in the account dropdown (`header.xhtml`).
- **Privilege.Import_Letters** added (used to gate the import UI in PRs #5/#6).

## Design notes
- Key management is **self-service for any logged-in user** (like *Change My Password*), so the page itself is not privilege-gated; the *import feature* will be. Happy to gate the key page too if you prefer.
- Raw key is dropped from memory right after encryption and is **never** read back into the page — only `sk-ant-••••last4` is shown.
- New entity auto-registers (`exclude-unlisted-classes=false`); a `user_claude_api_key` table will be created by the schema-generation strategy in use.
- **Set `DMIS_CRYPTO_SECRET` in production** so keys are not recoverable from a DB dump with the default passphrase.

## Testing
Build performed by the maintainer. Manual check: account menu → My Claude API Key → save a key → confirm masked display and that the raw value is not present in the rendered page or DB in clear text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)