### PR TITLE
Letter import (3/6): Anthropic client + grounded letter extraction

### DIFF
--- a/src/main/java/lk/gov/health/phsp/ejb/AnthropicApiService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/AnthropicApiService.java
@@ -1,0 +1,353 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ *
+ * Adapted from the HMIS project's com.divudi.service.AnthropicApiService,
+ * trimmed for DMIS and given DMIS-specific grounding tools.
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import lk.gov.health.phsp.entity.Institution;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.facade.InstitutionFacade;
+import lk.gov.health.phsp.facade.WebUserFacade;
+import lk.gov.health.phsp.pojcs.AnthropicResponse;
+
+/**
+ * Thin client for the Anthropic (Claude) Messages API, with an agentic
+ * tool-use loop exposing two DMIS grounding tools — {@code institution_search}
+ * and {@code staff_search} — so Claude can resolve a free-text institution or
+ * sender name to a real DMIS entity id while extracting letter metadata.
+ *
+ * <p>The key is always supplied per call (each user's own key); this service
+ * holds no application-wide key.</p>
+ *
+ * <p><strong>Runtime note:</strong> this uses the JDK {@code java.net.http}
+ * client (Java 11+), exactly as the HMIS reference does. The Maven build keeps
+ * {@code source/target = 1.8}, so it must be compiled and run on a JDK/JRE 11
+ * or newer. If the deployment JRE is genuinely Java 8, swap the HTTP calls to
+ * the already-present {@code unirest-java} dependency.</p>
+ */
+@Stateless
+public class AnthropicApiService implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(AnthropicApiService.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    private static final String MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
+    private static final String ANTHROPIC_VERSION = "2023-06-01";
+    private static final int MAX_TOOL_ITERATIONS = 8;
+    private static final int DEFAULT_SEARCH_LIMIT = 10;
+
+    @EJB
+    private InstitutionFacade institutionFacade;
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    /**
+     * Sends a single user message (optionally with a base64 attachment) to
+     * Claude and runs the agentic tool loop until Claude produces a final
+     * answer. Returns the final text plus accumulated token usage.
+     *
+     * @param apiKey             the user's Anthropic API key
+     * @param model              Claude model id (caller supplies a default)
+     * @param maxTokens          max response tokens
+     * @param systemPrompt       system prompt
+     * @param userMessage        the user text
+     * @param attachmentBase64   optional base64 attachment (PDF or image)
+     * @param attachmentMimeType optional MIME type, e.g. application/pdf
+     */
+    public AnthropicResponse sendMessage(
+            String apiKey,
+            String model,
+            int maxTokens,
+            String systemPrompt,
+            String userMessage,
+            String attachmentBase64,
+            String attachmentMimeType) {
+
+        try {
+            List<JsonObject> messages = new ArrayList<>();
+            messages.add(buildUserMessage(userMessage, attachmentBase64, attachmentMimeType));
+
+            JsonArray tools = buildToolsArray();
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(30))
+                    .build();
+
+            long totalInputTokens = 0L;
+            long totalOutputTokens = 0L;
+
+            final long loopDeadlineMs = System.currentTimeMillis() + (5 * 60 * 1000L);
+            final long perRequestMaxMs = 120_000L;
+
+            for (int iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
+                long remainingMs = loopDeadlineMs - System.currentTimeMillis();
+                if (remainingMs <= 0) {
+                    return new AnthropicResponse(
+                            "Request timed out: the agentic loop exceeded the 5-minute deadline.",
+                            totalInputTokens, totalOutputTokens);
+                }
+                long requestTimeoutMs = Math.min(perRequestMaxMs, remainingMs);
+
+                JsonArrayBuilder messagesBuilder = Json.createArrayBuilder();
+                for (JsonObject msg : messages) {
+                    messagesBuilder.add(msg);
+                }
+
+                JsonObject requestBody = Json.createObjectBuilder()
+                        .add("model", model != null ? model : "claude-sonnet-4-6")
+                        .add("max_tokens", maxTokens > 0 ? maxTokens : 4096)
+                        .add("system", systemPrompt != null ? systemPrompt : "")
+                        .add("tools", tools)
+                        .add("messages", messagesBuilder.build())
+                        .build();
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(MESSAGES_ENDPOINT))
+                        .timeout(Duration.ofMillis(requestTimeoutMs))
+                        .header("Content-Type", "application/json")
+                        .header("x-api-key", apiKey)
+                        .header("anthropic-version", ANTHROPIC_VERSION)
+                        .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 200) {
+                    LOG.log(Level.WARNING, "Anthropic API error {0}: {1}",
+                            new Object[]{response.statusCode(), response.body()});
+                    return new AnthropicResponse(
+                            "Error from AI service (HTTP " + response.statusCode() + "): " + response.body(),
+                            totalInputTokens, totalOutputTokens);
+                }
+
+                JsonObject responseJson;
+                try (JsonReader reader = Json.createReader(new StringReader(response.body()))) {
+                    responseJson = reader.readObject();
+                }
+
+                JsonObject usage = responseJson.getJsonObject("usage");
+                if (usage != null) {
+                    totalInputTokens += usage.getInt("input_tokens", 0);
+                    totalOutputTokens += usage.getInt("output_tokens", 0);
+                }
+
+                String stopReason = responseJson.getString("stop_reason", "end_turn");
+                JsonArray contentArray = responseJson.getJsonArray("content");
+
+                if ("end_turn".equals(stopReason) || !"tool_use".equals(stopReason)) {
+                    return new AnthropicResponse(
+                            extractTextFromContent(contentArray),
+                            totalInputTokens, totalOutputTokens);
+                }
+
+                // stop_reason == tool_use: echo assistant turn, then answer each tool call.
+                messages.add(Json.createObjectBuilder()
+                        .add("role", "assistant")
+                        .add("content", contentArray)
+                        .build());
+
+                JsonArrayBuilder toolResultsBuilder = Json.createArrayBuilder();
+                for (int i = 0; i < contentArray.size(); i++) {
+                    JsonObject block = contentArray.getJsonObject(i);
+                    if ("tool_use".equals(block.getString("type", ""))) {
+                        String toolId = block.getString("id", "");
+                        String toolName = block.getString("name", "");
+                        JsonObject toolInput = block.containsKey("input")
+                                ? block.getJsonObject("input")
+                                : Json.createObjectBuilder().build();
+                        String result = executeToolCall(toolName, toolInput);
+                        toolResultsBuilder.add(Json.createObjectBuilder()
+                                .add("type", "tool_result")
+                                .add("tool_use_id", toolId)
+                                .add("content", result));
+                    }
+                }
+                messages.add(Json.createObjectBuilder()
+                        .add("role", "user")
+                        .add("content", toolResultsBuilder.build())
+                        .build());
+            }
+
+            return new AnthropicResponse(
+                    "The AI reached the maximum number of tool-use steps.",
+                    totalInputTokens, totalOutputTokens);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.log(Level.SEVERE, "Anthropic API call interrupted", e);
+            return new AnthropicResponse("Request was interrupted. Please try again.", 0L, 0L);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Error calling Anthropic API", e);
+            return new AnthropicResponse("Error communicating with AI service: " + e.getMessage(), 0L, 0L);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Message / content helpers
+    // -------------------------------------------------------------------------
+
+    private JsonObject buildUserMessage(String userMessage, String attachmentBase64, String attachmentMimeType) {
+        if (attachmentBase64 != null && !attachmentBase64.isEmpty() && attachmentMimeType != null) {
+            JsonArrayBuilder contentBuilder = Json.createArrayBuilder();
+            JsonObject source = Json.createObjectBuilder()
+                    .add("type", "base64")
+                    .add("media_type", attachmentMimeType)
+                    .add("data", attachmentBase64)
+                    .build();
+            if (attachmentMimeType.startsWith("image/")) {
+                contentBuilder.add(Json.createObjectBuilder().add("type", "image").add("source", source));
+            } else {
+                contentBuilder.add(Json.createObjectBuilder().add("type", "document").add("source", source));
+            }
+            if (userMessage != null && !userMessage.trim().isEmpty()) {
+                contentBuilder.add(Json.createObjectBuilder().add("type", "text").add("text", userMessage));
+            }
+            return Json.createObjectBuilder().add("role", "user").add("content", contentBuilder.build()).build();
+        }
+        return Json.createObjectBuilder()
+                .add("role", "user")
+                .add("content", userMessage != null ? userMessage : "")
+                .build();
+    }
+
+    private String extractTextFromContent(JsonArray contentArray) {
+        if (contentArray == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < contentArray.size(); i++) {
+            JsonObject block = contentArray.getJsonObject(i);
+            if ("text".equals(block.getString("type", ""))) {
+                sb.append(block.getString("text", ""));
+            }
+        }
+        return sb.toString();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tools
+    // -------------------------------------------------------------------------
+
+    private JsonArray buildToolsArray() {
+        JsonObject institutionSearch = Json.createObjectBuilder()
+                .add("name", "institution_search")
+                .add("description",
+                        "Search DMIS institutions by name (case-insensitive contains). "
+                        + "Use this to resolve the sending institution printed on a letter to a "
+                        + "real DMIS institution id. Returns id, name, and type for each match.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Institution name or fragment to search for.")))
+                        .add("required", Json.createArrayBuilder().add("query")))
+                .build();
+
+        JsonObject staffSearch = Json.createObjectBuilder()
+                .add("name", "staff_search")
+                .add("description",
+                        "Search DMIS staff/users by name (case-insensitive contains). "
+                        + "Use this to resolve the named sender or signatory of a letter to a real "
+                        + "DMIS user id. Returns id and name for each match.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Person/user name or fragment to search for.")))
+                        .add("required", Json.createArrayBuilder().add("query")))
+                .build();
+
+        return Json.createArrayBuilder().add(institutionSearch).add(staffSearch).build();
+    }
+
+    private String executeToolCall(String toolName, JsonObject toolInput) {
+        try {
+            String query = toolInput.containsKey("query") ? toolInput.getString("query", "") : "";
+            switch (toolName) {
+                case "institution_search":
+                    return searchInstitutions(query);
+                case "staff_search":
+                    return searchStaff(query);
+                default:
+                    return "{\"error\":\"Unknown tool: " + toolName + "\"}";
+            }
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Tool " + toolName + " failed", e);
+            return "{\"error\":\"" + escape(e.getMessage()) + "\"}";
+        }
+    }
+
+    private String searchInstitutions(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            return "{\"results\":[]}";
+        }
+        String jpql = "SELECT i FROM Institution i WHERE i.retired = false "
+                + "AND lower(i.name) LIKE :q ORDER BY i.name";
+        Map<String, Object> params = new HashMap<>();
+        params.put("q", "%" + query.trim().toLowerCase() + "%");
+        List<Institution> matches = institutionFacade.findByJpql(jpql, params, DEFAULT_SEARCH_LIMIT);
+
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (Institution i : matches) {
+            JsonObject o = Json.createObjectBuilder()
+                    .add("id", i.getId())
+                    .add("name", i.getName() != null ? i.getName() : "")
+                    .add("type", i.getInstitutionType() != null ? i.getInstitutionType().toString() : "")
+                    .build();
+            arr.add(o);
+        }
+        return Json.createObjectBuilder().add("results", arr).build().toString();
+    }
+
+    private String searchStaff(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            return "{\"results\":[]}";
+        }
+        String jpql = "SELECT u FROM WebUser u WHERE u.retired = false "
+                + "AND (lower(u.name) LIKE :q OR lower(u.person.name) LIKE :q) ORDER BY u.name";
+        Map<String, Object> params = new HashMap<>();
+        params.put("q", "%" + query.trim().toLowerCase() + "%");
+        List<WebUser> matches = webUserFacade.findByJpql(jpql, params, DEFAULT_SEARCH_LIMIT);
+
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (WebUser u : matches) {
+            String name = u.getPerson() != null && u.getPerson().getName() != null
+                    ? u.getPerson().getName() : u.getName();
+            JsonObject o = Json.createObjectBuilder()
+                    .add("id", u.getId())
+                    .add("name", name != null ? name : "")
+                    .build();
+            arr.add(o);
+        }
+        return Json.createObjectBuilder().add("results", arr).build().toString();
+    }
+
+    private String escape(String s) {
+        return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/LetterExtractionService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/LetterExtractionService.java
@@ -1,0 +1,170 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import java.io.StringReader;
+import java.util.Base64;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+import lk.gov.health.phsp.pojcs.AnthropicResponse;
+import lk.gov.health.phsp.pojcs.LetterExtractionResult;
+
+/**
+ * Turns a single-letter PDF segment into structured {@link LetterExtractionResult}
+ * metadata by asking Claude to OCR it and resolve the sending institution /
+ * signatory against DMIS via the {@link AnthropicApiService} grounding tools.
+ */
+@Stateless
+public class LetterExtractionService implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(LetterExtractionService.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    private static final int MAX_TOKENS = 2048;
+
+    private static final String SYSTEM_PROMPT =
+            "You extract registry metadata from a SINGLE scanned letter supplied as a PDF. "
+            + "Sri Lankan government letters may be in Sinhala, Tamil, or English. "
+            + "OCR the letter, then resolve names to DMIS records:\n"
+            + "- Call institution_search to find the id of the SENDING institution (the one that "
+            + "issued the letter, usually in the letterhead).\n"
+            + "- Call staff_search to find the id of the named signatory/sender if a person is named.\n"
+            + "Only set a resolved id when a returned match is clearly the same entity; otherwise leave it null.\n\n"
+            + "Respond with ONLY a single JSON object (no markdown, no commentary) with exactly these keys:\n"
+            + "{\n"
+            + "  \"subject\": string,                 // letter subject/title, or a short summary\n"
+            + "  \"letterDate\": string|null,         // date on the letter as yyyy-MM-dd, else null\n"
+            + "  \"senderInstitutionName\": string|null,\n"
+            + "  \"resolvedInstitutionId\": number|null,\n"
+            + "  \"senderName\": string|null,\n"
+            + "  \"resolvedStaffId\": number|null,\n"
+            + "  \"registrationNo\": string|null,     // sender's outgoing/reference number if printed\n"
+            + "  \"referenceNo\": string|null,        // any 'your reference' number if printed\n"
+            + "  \"confidence\": number               // 0..1, your confidence in this extraction\n"
+            + "}";
+
+    @EJB
+    private AnthropicApiService anthropicApiService;
+
+    /**
+     * Extracts metadata from one letter segment. Never throws: on any failure a
+     * result with {@code errorMessage} set is returned so the reviewer can fill
+     * the fields manually.
+     *
+     * @param subPdfBytes a standalone PDF containing only this letter's pages
+     * @param apiKey      the user's Claude API key
+     * @param model       Claude model id (or null for the service default)
+     */
+    public LetterExtractionResult extractFromSegment(byte[] subPdfBytes, String apiKey, String model) {
+        LetterExtractionResult result = new LetterExtractionResult();
+        if (subPdfBytes == null || subPdfBytes.length == 0) {
+            result.setErrorMessage("Empty PDF segment.");
+            return result;
+        }
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            result.setErrorMessage("No Claude API key configured for this user.");
+            return result;
+        }
+        try {
+            String base64 = Base64.getEncoder().encodeToString(subPdfBytes);
+            AnthropicResponse response = anthropicApiService.sendMessage(
+                    apiKey, model, MAX_TOKENS, SYSTEM_PROMPT,
+                    "Extract the metadata for this letter as specified.",
+                    base64, "application/pdf");
+
+            result.setInputTokens(response.getInputTokens());
+            result.setOutputTokens(response.getOutputTokens());
+
+            String content = response.getContent();
+            result.setRawJson(content);
+            parseInto(content, result);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Letter extraction failed", e);
+            result.setErrorMessage("Extraction failed: " + e.getMessage());
+        }
+        return result;
+    }
+
+    private void parseInto(String content, LetterExtractionResult result) {
+        String json = stripToJson(content);
+        if (json == null) {
+            result.setErrorMessage("Claude did not return JSON. Raw: "
+                    + (content == null ? "null" : truncate(content)));
+            return;
+        }
+        try (JsonReader reader = Json.createReader(new StringReader(json))) {
+            JsonObject obj = reader.readObject();
+            result.setSubject(getString(obj, "subject"));
+            result.setLetterDate(getString(obj, "letterDate"));
+            result.setSenderInstitutionName(getString(obj, "senderInstitutionName"));
+            result.setResolvedInstitutionId(getLong(obj, "resolvedInstitutionId"));
+            result.setSenderName(getString(obj, "senderName"));
+            result.setResolvedStaffId(getLong(obj, "resolvedStaffId"));
+            result.setRegistrationNo(getString(obj, "registrationNo"));
+            result.setReferenceNo(getString(obj, "referenceNo"));
+            if (obj.containsKey("confidence") && !obj.isNull("confidence")) {
+                try {
+                    result.setConfidence(obj.getJsonNumber("confidence").doubleValue());
+                } catch (Exception ignore) {
+                    // leave confidence at 0
+                }
+            }
+        } catch (Exception e) {
+            result.setErrorMessage("Could not parse Claude JSON: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Extracts the first {@code { ... }} JSON object from Claude's text,
+     * tolerating ```json fences or stray prose around it.
+     */
+    private String stripToJson(String content) {
+        if (content == null) {
+            return null;
+        }
+        int start = content.indexOf('{');
+        int end = content.lastIndexOf('}');
+        if (start < 0 || end < 0 || end <= start) {
+            return null;
+        }
+        return content.substring(start, end + 1);
+    }
+
+    private String getString(JsonObject obj, String key) {
+        if (!obj.containsKey(key) || obj.isNull(key)) {
+            return null;
+        }
+        try {
+            return obj.getString(key);
+        } catch (Exception e) {
+            // value present but not a string
+            JsonValue v = obj.get(key);
+            return v != null ? v.toString() : null;
+        }
+    }
+
+    private Long getLong(JsonObject obj, String key) {
+        if (!obj.containsKey(key) || obj.isNull(key)) {
+            return null;
+        }
+        try {
+            return obj.getJsonNumber(key).longValue();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String truncate(String s) {
+        return s.length() > 300 ? s.substring(0, 300) + "..." : s;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/pojcs/AnthropicResponse.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/AnthropicResponse.java
@@ -1,0 +1,39 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+
+/**
+ * Result of a call to the Anthropic Messages API: the final assistant text plus
+ * the accumulated token usage across any agentic tool-use iterations.
+ */
+public class AnthropicResponse implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String content;
+    private final long inputTokens;
+    private final long outputTokens;
+
+    public AnthropicResponse(String content, long inputTokens, long outputTokens) {
+        this.content = content;
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public long getInputTokens() {
+        return inputTokens;
+    }
+
+    public long getOutputTokens() {
+        return outputTokens;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/pojcs/LetterExtractionResult.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/LetterExtractionResult.java
@@ -1,0 +1,79 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+
+/**
+ * Structured metadata extracted by Claude from a single letter (one PDF
+ * segment) for the letter-import review step. Identifier fields are populated
+ * only when Claude could resolve the printed name to a real DMIS entity via the
+ * grounding tools; otherwise the free-text name is kept for the reviewer.
+ */
+public class LetterExtractionResult implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String subject;
+    /** Letter date as printed, ISO yyyy-MM-dd when parseable, else null. */
+    private String letterDate;
+    private String senderInstitutionName;
+    private Long resolvedInstitutionId;
+    private String senderName;
+    private Long resolvedStaffId;
+    private String registrationNo;
+    private String referenceNo;
+    /** Claude's self-reported confidence, 0..1. */
+    private double confidence;
+
+    /** The raw JSON returned by Claude, kept for auditing/debugging. */
+    private String rawJson;
+    private long inputTokens;
+    private long outputTokens;
+    /** Non-null if extraction failed; the reviewer then fills fields manually. */
+    private String errorMessage;
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+
+    public String getLetterDate() { return letterDate; }
+    public void setLetterDate(String letterDate) { this.letterDate = letterDate; }
+
+    public String getSenderInstitutionName() { return senderInstitutionName; }
+    public void setSenderInstitutionName(String senderInstitutionName) { this.senderInstitutionName = senderInstitutionName; }
+
+    public Long getResolvedInstitutionId() { return resolvedInstitutionId; }
+    public void setResolvedInstitutionId(Long resolvedInstitutionId) { this.resolvedInstitutionId = resolvedInstitutionId; }
+
+    public String getSenderName() { return senderName; }
+    public void setSenderName(String senderName) { this.senderName = senderName; }
+
+    public Long getResolvedStaffId() { return resolvedStaffId; }
+    public void setResolvedStaffId(Long resolvedStaffId) { this.resolvedStaffId = resolvedStaffId; }
+
+    public String getRegistrationNo() { return registrationNo; }
+    public void setRegistrationNo(String registrationNo) { this.registrationNo = registrationNo; }
+
+    public String getReferenceNo() { return referenceNo; }
+    public void setReferenceNo(String referenceNo) { this.referenceNo = referenceNo; }
+
+    public double getConfidence() { return confidence; }
+    public void setConfidence(double confidence) { this.confidence = confidence; }
+
+    public String getRawJson() { return rawJson; }
+    public void setRawJson(String rawJson) { this.rawJson = rawJson; }
+
+    public long getInputTokens() { return inputTokens; }
+    public void setInputTokens(long inputTokens) { this.inputTokens = inputTokens; }
+
+    public long getOutputTokens() { return outputTokens; }
+    public void setOutputTokens(long outputTokens) { this.outputTokens = outputTokens; }
+
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
+    public boolean isFailed() { return errorMessage != null; }
+}


### PR DESCRIPTION
Closes #116. Part 3 of the user-keyed Claude letter-import feature (`docs/letter-import-plan.md`).

## What
- **AnthropicResponse** (pojcs) — final assistant text + accumulated token usage.
- **AnthropicApiService** (Stateless EJB) — JDK `HttpClient` call to `api.anthropic.com/v1/messages` with an agentic tool loop; the key is supplied **per call** (each user’s own key, no app-wide key). Grounding tools **`institution_search`** / **`staff_search`** run DMIS JPQL so Claude resolves printed names to real `Institution`/`WebUser` ids.
- **LetterExtractionResult** (pojcs) — subject, letterDate, sender institution/name, resolved ids, registration/reference no, confidence, token usage, error.
- **LetterExtractionService** (Stateless EJB) — sends the per-letter PDF as a `document` block, instructs strict-JSON output, parses it. Never throws: on failure it returns a result with `errorMessage` so the reviewer fills fields manually.

## Resolved open question (JRE)
Implemented with the JDK `java.net.http` client, **matching the HMIS reference**. The Maven build keeps `source/target = 1.8`, so this must be **compiled and run on JDK/JRE 11+** (no `--release 8`). If your deployment JRE is truly Java 8, say so and I’ll swap to the already-present `unirest-java`. Please confirm your Payara/runtime JDK.

## Depends on
#115 (per-user key) for the actual key value at call time — wired in PR #4/#5.

## Testing
Build performed by the maintainer. Functional check arrives with the orchestration in PR #4 (#117): feed a one-letter PDF and confirm a populated `LetterExtractionResult` with a resolved institution id when the letterhead matches a DMIS institution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)