### PR TITLE
Letter import (6/6): Config, scheduled cleanup, and docs

### DIFF
--- a/docs/letter-import-plan.md
+++ b/docs/letter-import-plan.md
@@ -1,0 +1,62 @@
+# Plan: User-keyed Claude letter import (PDF → split → OCR → review → create)
+
+## Goal
+Let users upload a multi-page PDF in which individual letters are separated by
+blank pages. The application temporarily holds the PDF, uses **the logged-in
+user's own Claude API key** to OCR and split it into per-letter segments, renders
+each letter to image(s), and proposes letter metadata (subject, letter date,
+stamp/received date defaulting to today, sending institution/sender — grounded
+against the in-built institution/staff API). The user reviews each proposed
+letter and may **Accept & Create**, **Save edits**, **Discard**, or **Skip**.
+
+## Design decisions (approved)
+- **Split:** PDFBox detects blank separator pages locally and segments the PDF;
+  each segment is sent to Claude (user's key) for OCR + metadata.
+- **Key storage:** dedicated `UserClaudeApiKey` entity, AES-GCM encrypted at
+  rest, one active key per user, masked in UI, never returned to the browser.
+- **Staging:** `LetterImportBatch` + `LetterImportItem` persist the PDF and
+  per-letter proposals; resumable, with a scheduled cleanup job.
+- **Grounding:** Claude is given in-process `institution_search` / `staff_search`
+  tools (the HMIS agentic pattern) so the proposed sender resolves to a real
+  entity; UI autocomplete is the fallback.
+
+## Key facts about the codebase
+- A "letter" is the `Document` entity; managed by session-scoped
+  `LetterController`. Attachments are the `Upload` entity (`baImage` LONGBLOB).
+- An internal REST API already exists (`Api-Key` header): `InstitutionResource`,
+  `UserResource`, `LetterResource`.
+- Java 8 source target. PDF libs present: itext + flying-saucer (neither can
+  rasterize) → add **PDFBox 2.0.x**.
+- HMIS reference: `com.divudi.service.AnthropicApiService` (Stateless EJB, Java
+  `HttpClient`, agentic tool loop, image+document base64 blocks). HMIS uses one
+  app-wide key; DMIS must be per-user instead.
+
+## Issues / PRs (sequential)
+1. **PDF segmentation & rendering service** — add PDFBox; `PdfSplitService`
+   (`detectSegments`, `extractSubPdf`, `renderPagesToPng`).
+2. **Per-user encrypted Claude API key** — `UserClaudeApiKey` entity + facade,
+   `CryptoService` (AES-GCM), `ClaudeApiKeyController`, `claude_api_key.xhtml`
+   under "Manage My API Keys" menu, new privilege.
+3. **AnthropicApiService port + DMIS tools** — port/trim HMIS service into
+   `lk.gov.health.phsp.ejb`; add `institution_search`/`staff_search` tools;
+   `LetterExtractionService.extractFromSegment` → strict-JSON metadata + usage.
+   Open question: confirm runtime JRE (Java 11+ keeps JDK HttpClient; true Java 8
+   → Apache HttpClient).
+4. **Staging entities + async orchestration** — `LetterImportBatch` /
+   `LetterImportItem` + facades; `LetterImportService` (`@Asynchronous`):
+   detect → render + Claude extract → persist items; progress tracking.
+5. **Review wizard UI + create-letter integration** — `LetterImportController`,
+   `letter_import.xhtml` (upload → progress poll → wizard), Accept & Create /
+   Save / Discard / Skip; reuse `LetterController`/`uploadFacade` patterns; menu
+   + privilege.
+6. **Config, cleanup, privileges, docs** — ConfigOptions (model, max pages,
+   blank threshold, DPI, retention days), `@Schedule` cleanup, docs.
+
+PRs land 1 → 2 → 3 → 4 → 5 → 6. Issues 1/2/3 have no cross-deps and may be
+parallelized; 5 depends on 1–4; 3 depends on 2.
+
+## Risks
+- Runtime JRE drives the HTTP-client choice (Issue 3).
+- Cost is on the user's own key; mitigated by per-request page caps + cheaper
+  default model.
+- Security: AES-GCM at rest, masked display, key excluded from DTOs/logs.

--- a/docs/letter-import.md
+++ b/docs/letter-import.md
@@ -1,0 +1,83 @@
+# Letter import (PDF → split → OCR → review → create)
+
+This feature lets a user upload a single PDF that contains many letters
+separated by blank pages. The application splits it into individual letters,
+OCRs each one with **the user's own Claude API key**, proposes registry
+metadata, and lets the user review and create letters one by one.
+
+## Setup
+
+### 1. Per-user Claude API key
+Each user provides their own Anthropic key (billing is on their own account):
+
+- Account menu (top-right) → **My Claude API Key**
+- Paste the key (`sk-ant-...`), optionally set a model override, **Save Key**.
+- The key is stored **encrypted** (`CryptoService`, Jasypt `StrongTextEncryptor`)
+  and never shown again — only `sk-ant-••••last4`.
+
+Get a key at <https://console.anthropic.com/settings/keys>.
+
+### 2. Privilege
+Grant the **Import Letters from PDF** privilege (`Privilege.Import_Letters`) to
+users who may use the feature. The menu item (Create ▸ *Import Letters from PDF*)
+and page are gated by it.
+
+### 3. Operator configuration
+Set the encryption secret in production so keys are not recoverable from a DB
+dump with the default passphrase:
+
+```
+-Ddmis.crypto.secret=<long-random-string>        # or env DMIS_CRYPTO_SECRET
+```
+
+Optional tuning (system property → env var → default), read by
+`LetterImportConfig`:
+
+| Setting | System property | Env var | Default |
+|---|---|---|---|
+| Default Claude model | `dmis.letterImport.model` | `DMIS_LETTER_IMPORT_MODEL` | `claude-sonnet-4-6` |
+| Blank-page threshold (ink fraction) | `dmis.letterImport.blankThreshold` | `DMIS_LETTER_IMPORT_BLANK_THRESHOLD` | `0.005` |
+| Render DPI | `dmis.letterImport.renderDpi` | `DMIS_LETTER_IMPORT_RENDER_DPI` | `150` |
+| Max pages per PDF | `dmis.letterImport.maxPages` | `DMIS_LETTER_IMPORT_MAX_PAGES` | `500` |
+| Batch retention days | `dmis.letterImport.retentionDays` | `DMIS_LETTER_IMPORT_RETENTION_DAYS` | `7` |
+
+## Workflow
+
+1. **Create ▸ Import Letters from PDF**.
+2. **Upload** a PDF whose individual letters are separated by blank pages.
+3. **Start Processing.** A background job (`LetterImportService`, `@Asynchronous`)
+   splits the PDF at blank pages (`PdfSplitService`), renders a preview, and asks
+   Claude to OCR each letter and resolve the sending institution / signatory to
+   real DMIS records (`institution_search` / `staff_search` tools). The page
+   shows a live progress bar.
+4. **Review** each letter: the rendered page on the left, the proposed metadata
+   on the right (subject, letter date, **stamp/received date defaulting to
+   today**, from-institution, sender name, registration/reference no).
+   - **Accept & Create** — creates a `DocumentType.Letter` letter and attaches
+     the rendered page image(s).
+   - **Save Edits** — keeps your edits on the staged item without creating a
+     letter yet.
+   - **Discard** — drops the letter.
+   - **Skip / Next**, **Previous** — navigate without deciding.
+
+## Data lifecycle & privacy
+
+- The uploaded PDF and per-letter proposals are held in `LetterImportBatch` /
+  `LetterImportItem` only until reviewed; a scheduled job
+  (`LetterImportCleanupBean`, every 6 h) purges batches older than the retention
+  window.
+- Letter content is sent to Anthropic for OCR using the user's own key. No
+  application-wide key is used and keys are never logged.
+
+## Components
+
+| Concern | Class |
+|---|---|
+| PDF split / render | `ejb/PdfSplitService` |
+| Per-user key | `entity/UserClaudeApiKey`, `bean/ClaudeApiKeyController`, `ejb/CryptoService` |
+| Claude client + tools | `ejb/AnthropicApiService` |
+| Metadata extraction | `ejb/LetterExtractionService` |
+| Staging | `entity/LetterImportBatch`, `entity/LetterImportItem` (+ facades) |
+| Orchestration | `ejb/LetterImportService`, `ejb/LetterImportTxBean` |
+| Review UI | `bean/LetterImportController`, `webapp/document/letter_import.xhtml` |
+| Config / cleanup | `ejb/LetterImportConfig`, `ejb/LetterImportCleanupBean` |

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,15 @@
             <type>jar</type>
         </dependency>
 
+        <!-- PDFBox 2.0.x: Java 8 compatible. Used to detect blank separator
+             pages, split a multi-letter PDF into per-letter sub-PDFs, and
+             rasterize pages to PNG for the letter-import feature. -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.31</version>
+        </dependency>
+
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.core</artifactId>

--- a/src/main/java/lk/gov/health/phsp/bean/ClaudeApiKeyController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ClaudeApiKeyController.java
@@ -1,0 +1,186 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.bean;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lk.gov.health.phsp.bean.util.JsfUtil;
+import lk.gov.health.phsp.ejb.CryptoService;
+import lk.gov.health.phsp.entity.UserClaudeApiKey;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.facade.UserClaudeApiKeyFacade;
+
+/**
+ * Self-service management of the logged-in user's personal Claude API key.
+ *
+ * <p>The raw key is encrypted via {@link CryptoService} before persistence and
+ * is never read back into the page; only a masked hint is shown. Other features
+ * (letter import) obtain the usable key through
+ * {@link #getActiveDecryptedKey(WebUser)}.</p>
+ */
+@Named
+@SessionScoped
+public class ClaudeApiKeyController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private UserClaudeApiKeyFacade userClaudeApiKeyFacade;
+    @EJB
+    private CryptoService cryptoService;
+    @Inject
+    private WebUserController webUserController;
+
+    /** Transient raw key typed by the user; never persisted as-is. */
+    private String rawKeyInput;
+    private String modelOverride;
+    private UserClaudeApiKey activeKey;
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+
+    public String toManageMyClaudeApiKey() {
+        rawKeyInput = null;
+        loadActiveKey();
+        modelOverride = activeKey != null ? activeKey.getModelOverride() : null;
+        return "/change_my_claude_api_key?faces-redirect=true";
+    }
+
+    // -------------------------------------------------------------------------
+    // Actions
+    // -------------------------------------------------------------------------
+
+    public void saveKey() {
+        WebUser user = webUserController.getLoggedUser();
+        if (user == null) {
+            JsfUtil.addErrorMessage("No logged-in user.");
+            return;
+        }
+        if (rawKeyInput == null || rawKeyInput.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please paste your Claude API key.");
+            return;
+        }
+        String raw = rawKeyInput.trim();
+
+        loadActiveKey();
+        if (activeKey != null) {
+            retire(activeKey, "Replaced by a new key", user);
+        }
+
+        UserClaudeApiKey key = new UserClaudeApiKey();
+        key.setOwner(user);
+        key.setEncryptedKey(cryptoService.encrypt(raw));
+        key.setLast4(raw.length() >= 4 ? raw.substring(raw.length() - 4) : raw);
+        key.setModelOverride(modelOverride != null && !modelOverride.trim().isEmpty()
+                ? modelOverride.trim() : null);
+        key.setActive(true);
+        key.setCreatedBy(user);
+        key.setCreatedAt(new Date());
+        userClaudeApiKeyFacade.create(key);
+
+        // Drop the raw value from memory as soon as it is stored.
+        rawKeyInput = null;
+        activeKey = key;
+        JsfUtil.addSuccessMessage("Your Claude API key has been saved securely.");
+    }
+
+    public void removeKey() {
+        WebUser user = webUserController.getLoggedUser();
+        loadActiveKey();
+        if (activeKey == null) {
+            JsfUtil.addErrorMessage("No key to remove.");
+            return;
+        }
+        retire(activeKey, "Removed by user", user);
+        activeKey = null;
+        modelOverride = null;
+        JsfUtil.addSuccessMessage("Your Claude API key has been removed.");
+    }
+
+    private void retire(UserClaudeApiKey key, String comment, WebUser user) {
+        key.setActive(false);
+        key.setRetired(true);
+        key.setRetiredBy(user);
+        key.setRetiredAt(new Date());
+        key.setRetireComments(comment);
+        userClaudeApiKeyFacade.edit(key);
+    }
+
+    // -------------------------------------------------------------------------
+    // Lookup helpers (used here and by the letter-import feature)
+    // -------------------------------------------------------------------------
+
+    private void loadActiveKey() {
+        activeKey = findActiveKey(webUserController.getLoggedUser());
+    }
+
+    public UserClaudeApiKey findActiveKey(WebUser user) {
+        if (user == null) {
+            return null;
+        }
+        String jpql = "SELECT k FROM UserClaudeApiKey k "
+                + "WHERE k.owner = :owner AND k.active = true AND k.retired = false "
+                + "ORDER BY k.id DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("owner", user);
+        List<UserClaudeApiKey> results = userClaudeApiKeyFacade.findByJpql(jpql, params);
+        return results.isEmpty() ? null : results.get(0);
+    }
+
+    /**
+     * Returns the decrypted, usable Claude API key for the given user, or
+     * {@code null} if they have not configured one.
+     */
+    public String getActiveDecryptedKey(WebUser user) {
+        UserClaudeApiKey key = findActiveKey(user);
+        if (key == null || key.getEncryptedKey() == null) {
+            return null;
+        }
+        return cryptoService.decrypt(key.getEncryptedKey());
+    }
+
+    // -------------------------------------------------------------------------
+    // View state
+    // -------------------------------------------------------------------------
+
+    public boolean isKeyConfigured() {
+        if (activeKey == null) {
+            loadActiveKey();
+        }
+        return activeKey != null;
+    }
+
+    public String getMaskedKey() {
+        if (activeKey == null) {
+            loadActiveKey();
+        }
+        if (activeKey == null) {
+            return "Not set";
+        }
+        return "sk-ant-••••••••••••" + (activeKey.getLast4() != null ? activeKey.getLast4() : "");
+    }
+
+    public String getRawKeyInput() { return rawKeyInput; }
+    public void setRawKeyInput(String rawKeyInput) { this.rawKeyInput = rawKeyInput; }
+
+    public String getModelOverride() { return modelOverride; }
+    public void setModelOverride(String modelOverride) { this.modelOverride = modelOverride; }
+
+    public UserClaudeApiKey getActiveKey() {
+        if (activeKey == null) {
+            loadActiveKey();
+        }
+        return activeKey;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/bean/LetterImportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/LetterImportController.java
@@ -20,6 +20,7 @@ import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lk.gov.health.phsp.bean.util.JsfUtil;
+import lk.gov.health.phsp.ejb.LetterImportConfig;
 import lk.gov.health.phsp.ejb.LetterImportService;
 import lk.gov.health.phsp.ejb.PdfSplitService;
 import lk.gov.health.phsp.entity.Document;
@@ -52,9 +53,8 @@ public class LetterImportController implements Serializable {
     private static final Logger LOG = Logger.getLogger(LetterImportController.class.getName());
     private static final long serialVersionUID = 1L;
 
-    /** Default Claude model; overridable per user, and configurable in PR #6. */
-    private static final String DEFAULT_MODEL = "claude-sonnet-4-6";
-
+    @EJB
+    private LetterImportConfig config;
     @EJB
     private LetterImportBatchFacade batchFacade;
     @EJB
@@ -147,7 +147,7 @@ public class LetterImportController implements Serializable {
     private String resolveModel() {
         String override = claudeApiKeyController.getActiveKey() != null
                 ? claudeApiKeyController.getActiveKey().getModelOverride() : null;
-        return override != null && !override.trim().isEmpty() ? override.trim() : DEFAULT_MODEL;
+        return override != null && !override.trim().isEmpty() ? override.trim() : config.getDefaultModel();
     }
 
     /** Polled by the page while a batch is processing. */

--- a/src/main/java/lk/gov/health/phsp/bean/LetterImportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/LetterImportController.java
@@ -1,0 +1,416 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.bean;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lk.gov.health.phsp.bean.util.JsfUtil;
+import lk.gov.health.phsp.ejb.LetterImportService;
+import lk.gov.health.phsp.ejb.PdfSplitService;
+import lk.gov.health.phsp.entity.Document;
+import lk.gov.health.phsp.entity.Institution;
+import lk.gov.health.phsp.entity.LetterImportBatch;
+import lk.gov.health.phsp.entity.LetterImportItem;
+import lk.gov.health.phsp.entity.Upload;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.enums.DocumentType;
+import lk.gov.health.phsp.enums.LetterImportItemStatus;
+import lk.gov.health.phsp.enums.LetterImportStatus;
+import lk.gov.health.phsp.facade.DocumentFacade;
+import lk.gov.health.phsp.facade.InstitutionFacade;
+import lk.gov.health.phsp.facade.LetterImportBatchFacade;
+import lk.gov.health.phsp.facade.LetterImportItemFacade;
+import lk.gov.health.phsp.facade.UploadFacade;
+import org.apache.commons.io.IOUtils;
+import org.primefaces.event.FileUploadEvent;
+import org.primefaces.model.file.UploadedFile;
+
+/**
+ * Drives the letter-import page: upload a multi-letter PDF, watch background
+ * processing, then review each detected letter and accept (create a letter),
+ * edit, discard, or skip it.
+ */
+@Named
+@SessionScoped
+public class LetterImportController implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(LetterImportController.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    /** Default Claude model; overridable per user, and configurable in PR #6. */
+    private static final String DEFAULT_MODEL = "claude-sonnet-4-6";
+
+    @EJB
+    private LetterImportBatchFacade batchFacade;
+    @EJB
+    private LetterImportItemFacade itemFacade;
+    @EJB
+    private DocumentFacade documentFacade;
+    @EJB
+    private UploadFacade uploadFacade;
+    @EJB
+    private InstitutionFacade institutionFacade;
+    @EJB
+    private PdfSplitService pdfSplitService;
+    @EJB
+    private LetterImportService letterImportService;
+
+    @Inject
+    private WebUserController webUserController;
+    @Inject
+    private ClaudeApiKeyController claudeApiKeyController;
+
+    private UploadedFile file;
+    private LetterImportBatch batch;
+    private List<LetterImportItem> items;
+    private int currentIndex;
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+
+    public String toLetterImport() {
+        file = null;
+        batch = null;
+        items = new ArrayList<>();
+        currentIndex = 0;
+        return "/document/letter_import?faces-redirect=true";
+    }
+
+    // -------------------------------------------------------------------------
+    // Upload + processing
+    // -------------------------------------------------------------------------
+
+    public void handleUpload(FileUploadEvent event) {
+        this.file = event.getFile();
+        JsfUtil.addSuccessMessage("Uploaded " + file.getFileName() + ". Click Start to process.");
+    }
+
+    public void startImport() {
+        WebUser user = webUserController.getLoggedUser();
+        if (user == null) {
+            JsfUtil.addErrorMessage("No logged-in user.");
+            return;
+        }
+        if (file == null) {
+            JsfUtil.addErrorMessage("Please choose a PDF file first.");
+            return;
+        }
+        String apiKey = claudeApiKeyController.getActiveDecryptedKey(user);
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Set your Claude API key first (account menu → My Claude API Key).");
+            return;
+        }
+
+        byte[] bytes;
+        try (InputStream in = file.getInputStream()) {
+            bytes = IOUtils.toByteArray(in);
+        } catch (IOException ex) {
+            LOG.log(Level.SEVERE, "Failed reading uploaded PDF", ex);
+            JsfUtil.addErrorMessage("Could not read the uploaded file.");
+            return;
+        }
+
+        LetterImportBatch b = new LetterImportBatch();
+        b.setOwner(user);
+        b.setInstitution(webUserController.getLoggedInstitution());
+        b.setOriginalFileName(file.getFileName());
+        b.setPdfBytes(bytes);
+        b.setStatus(LetterImportStatus.NEW);
+        b.setModel(resolveModel());
+        b.setCreatedBy(user);
+        b.setCreatedAt(new Date());
+        batchFacade.create(b);
+        this.batch = b;
+        this.items = new ArrayList<>();
+        this.currentIndex = 0;
+
+        letterImportService.processBatch(b.getId(), apiKey, b.getModel());
+        JsfUtil.addSuccessMessage("Processing started. Letters will appear as they are recognised.");
+    }
+
+    private String resolveModel() {
+        String override = claudeApiKeyController.getActiveKey() != null
+                ? claudeApiKeyController.getActiveKey().getModelOverride() : null;
+        return override != null && !override.trim().isEmpty() ? override.trim() : DEFAULT_MODEL;
+    }
+
+    /** Polled by the page while a batch is processing. */
+    public void refreshStatus() {
+        if (batch == null) {
+            return;
+        }
+        batch = batchFacade.find(batch.getId());
+        if (batch != null && batch.getStatus() == LetterImportStatus.READY && (items == null || items.isEmpty())) {
+            loadItems();
+        }
+    }
+
+    private void loadItems() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("b", batch);
+        items = itemFacade.findByJpql(
+                "SELECT i FROM LetterImportItem i WHERE i.batch = :b ORDER BY i.segmentIndex",
+                params);
+        if (items == null) {
+            items = new ArrayList<>();
+        }
+        currentIndex = 0;
+    }
+
+    public boolean isProcessing() {
+        return batch != null
+                && (batch.getStatus() == LetterImportStatus.NEW
+                || batch.getStatus() == LetterImportStatus.PROCESSING);
+    }
+
+    public boolean isReady() {
+        return batch != null && batch.getStatus() == LetterImportStatus.READY;
+    }
+
+    public boolean isFailed() {
+        return batch != null && batch.getStatus() == LetterImportStatus.FAILED;
+    }
+
+    public int getProgressPercent() {
+        if (batch == null || batch.getLetterCount() == null || batch.getLetterCount() == 0) {
+            return 0;
+        }
+        int processed = batch.getProcessedCount() != null ? batch.getProcessedCount() : 0;
+        return (int) Math.round((processed * 100.0) / batch.getLetterCount());
+    }
+
+    // -------------------------------------------------------------------------
+    // Review actions
+    // -------------------------------------------------------------------------
+
+    public LetterImportItem getCurrentItem() {
+        if (items == null || items.isEmpty() || currentIndex < 0 || currentIndex >= items.size()) {
+            return null;
+        }
+        return items.get(currentIndex);
+    }
+
+    public void next() {
+        if (items != null && currentIndex < items.size() - 1) {
+            currentIndex++;
+        }
+    }
+
+    public void previous() {
+        if (currentIndex > 0) {
+            currentIndex--;
+        }
+    }
+
+    public boolean isHasNext() {
+        return items != null && currentIndex < items.size() - 1;
+    }
+
+    public boolean isHasPrevious() {
+        return currentIndex > 0;
+    }
+
+    public void saveCurrentEdits() {
+        LetterImportItem item = getCurrentItem();
+        if (item == null) {
+            return;
+        }
+        itemFacade.edit(item);
+        JsfUtil.addSuccessMessage("Saved.");
+    }
+
+    public void acceptCurrent() {
+        LetterImportItem item = getCurrentItem();
+        if (item == null) {
+            return;
+        }
+        if (item.getStatus() == LetterImportItemStatus.ACCEPTED) {
+            JsfUtil.addErrorMessage("This letter was already accepted.");
+            return;
+        }
+        WebUser user = webUserController.getLoggedUser();
+        Institution loggedInstitution = webUserController.getLoggedInstitution();
+
+        Document doc = new Document();
+        doc.setDocumentType(DocumentType.Letter);
+        doc.setDocumentName(item.getSubject());
+        doc.setDocumentDate(item.getLetterDate());
+        doc.setReceivedDate(item.getReceivedDate() != null ? item.getReceivedDate() : new Date());
+        doc.setSenderName(item.getSenderName());
+        doc.setRegistrationNo(item.getRegistrationNo());
+        doc.setFromInstitution(item.getResolvedInstitution());
+        doc.setFromWebUser(item.getResolvedStaff());
+        doc.setInstitution(loggedInstitution);
+        doc.setCurrentInstitution(loggedInstitution);
+        doc.setCreatedInstitution(loggedInstitution);
+        doc.setOwner(user);
+        doc.setCurrentOwner(user);
+        doc.setCreatedBy(user);
+        doc.setCreatedAt(new Date());
+        documentFacade.create(doc);
+
+        attachRenderedPages(item, doc, user, loggedInstitution);
+
+        item.setStatus(LetterImportItemStatus.ACCEPTED);
+        item.setCreatedDocument(doc);
+        item.setDecidedAt(new Date());
+        itemFacade.edit(item);
+
+        refreshBatchDoneState();
+        JsfUtil.addSuccessMessage("Letter created.");
+        advancePastDecided();
+    }
+
+    private void attachRenderedPages(LetterImportItem item, Document doc, WebUser user, Institution institution) {
+        byte[] pdf = batch.getPdfBytes();
+        int start = item.getStartPage() != null ? item.getStartPage() : 0;
+        int end = item.getEndPage() != null ? item.getEndPage() : start;
+        for (int page = start; page <= end; page++) {
+            try {
+                byte[] png = pdfSplitService.renderPageToPng(pdf, page);
+                Upload up = new Upload();
+                up.setDocument(doc);
+                up.setBaImage(png);
+                up.setFileName("letter-" + doc.getId() + "-p" + (page - start + 1) + ".png");
+                up.setFileType("image/png");
+                up.setInstitution(institution);
+                up.setCreatedAt(new Date());
+                up.setCreater(user);
+                uploadFacade.create(up);
+            } catch (Exception e) {
+                LOG.log(Level.WARNING, "Failed attaching page " + page, e);
+            }
+        }
+    }
+
+    public void discardCurrent() {
+        LetterImportItem item = getCurrentItem();
+        if (item == null) {
+            return;
+        }
+        item.setStatus(LetterImportItemStatus.DISCARDED);
+        item.setDecidedAt(new Date());
+        itemFacade.edit(item);
+        refreshBatchDoneState();
+        JsfUtil.addSuccessMessage("Letter discarded.");
+        advancePastDecided();
+    }
+
+    public void skipCurrent() {
+        next();
+    }
+
+    private void advancePastDecided() {
+        if (isHasNext()) {
+            next();
+        }
+    }
+
+    private void refreshBatchDoneState() {
+        if (batch == null) {
+            return;
+        }
+        boolean allDecided = true;
+        for (LetterImportItem i : items) {
+            if (i.getStatus() == LetterImportItemStatus.PENDING) {
+                allDecided = false;
+                break;
+            }
+        }
+        if (allDecided) {
+            batch.setStatus(LetterImportStatus.DONE);
+            batchFacade.edit(batch);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Autocomplete
+    // -------------------------------------------------------------------------
+
+    public List<Institution> completeInstitution(String query) {
+        Map<String, Object> params = new HashMap<>();
+        String jpql = "SELECT i FROM Institution i WHERE i.retired = false";
+        if (query != null && !query.trim().isEmpty()) {
+            jpql += " AND lower(i.name) LIKE :q";
+            params.put("q", "%" + query.trim().toLowerCase() + "%");
+        }
+        jpql += " ORDER BY i.name";
+        return institutionFacade.findByJpql(jpql, params, 20);
+    }
+
+    // -------------------------------------------------------------------------
+    // Counts
+    // -------------------------------------------------------------------------
+
+    public int getPendingCount() {
+        if (items == null) {
+            return 0;
+        }
+        int count = 0;
+        for (LetterImportItem i : items) {
+            if (i.getStatus() == LetterImportItemStatus.PENDING) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public int getAcceptedCount() {
+        if (items == null) {
+            return 0;
+        }
+        int count = 0;
+        for (LetterImportItem i : items) {
+            if (i.getStatus() == LetterImportItemStatus.ACCEPTED) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters / setters
+    // -------------------------------------------------------------------------
+
+    public UploadedFile getFile() { return file; }
+    public void setFile(UploadedFile file) { this.file = file; }
+
+    public LetterImportBatch getBatch() { return batch; }
+
+    public List<LetterImportItem> getItems() { return items; }
+
+    public int getCurrentIndex() { return currentIndex; }
+    public void setCurrentIndex(int currentIndex) { this.currentIndex = currentIndex; }
+
+    public int getItemCount() { return items == null ? 0 : items.size(); }
+
+    /**
+     * The current letter's preview image as a data URI, for direct rendering in
+     * the page without a streaming endpoint. Empty string when no image.
+     */
+    public String getCurrentPreviewDataUri() {
+        LetterImportItem item = getCurrentItem();
+        if (item == null || item.getPreviewImage() == null || item.getPreviewImage().length == 0) {
+            return "";
+        }
+        String type = item.getPreviewContentType() != null ? item.getPreviewContentType() : "image/png";
+        return "data:" + type + ";base64,"
+                + java.util.Base64.getEncoder().encodeToString(item.getPreviewImage());
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/AnthropicApiService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/AnthropicApiService.java
@@ -1,0 +1,353 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ *
+ * Adapted from the HMIS project's com.divudi.service.AnthropicApiService,
+ * trimmed for DMIS and given DMIS-specific grounding tools.
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import lk.gov.health.phsp.entity.Institution;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.facade.InstitutionFacade;
+import lk.gov.health.phsp.facade.WebUserFacade;
+import lk.gov.health.phsp.pojcs.AnthropicResponse;
+
+/**
+ * Thin client for the Anthropic (Claude) Messages API, with an agentic
+ * tool-use loop exposing two DMIS grounding tools — {@code institution_search}
+ * and {@code staff_search} — so Claude can resolve a free-text institution or
+ * sender name to a real DMIS entity id while extracting letter metadata.
+ *
+ * <p>The key is always supplied per call (each user's own key); this service
+ * holds no application-wide key.</p>
+ *
+ * <p><strong>Runtime note:</strong> this uses the JDK {@code java.net.http}
+ * client (Java 11+), exactly as the HMIS reference does. The Maven build keeps
+ * {@code source/target = 1.8}, so it must be compiled and run on a JDK/JRE 11
+ * or newer. If the deployment JRE is genuinely Java 8, swap the HTTP calls to
+ * the already-present {@code unirest-java} dependency.</p>
+ */
+@Stateless
+public class AnthropicApiService implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(AnthropicApiService.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    private static final String MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
+    private static final String ANTHROPIC_VERSION = "2023-06-01";
+    private static final int MAX_TOOL_ITERATIONS = 8;
+    private static final int DEFAULT_SEARCH_LIMIT = 10;
+
+    @EJB
+    private InstitutionFacade institutionFacade;
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    /**
+     * Sends a single user message (optionally with a base64 attachment) to
+     * Claude and runs the agentic tool loop until Claude produces a final
+     * answer. Returns the final text plus accumulated token usage.
+     *
+     * @param apiKey             the user's Anthropic API key
+     * @param model              Claude model id (caller supplies a default)
+     * @param maxTokens          max response tokens
+     * @param systemPrompt       system prompt
+     * @param userMessage        the user text
+     * @param attachmentBase64   optional base64 attachment (PDF or image)
+     * @param attachmentMimeType optional MIME type, e.g. application/pdf
+     */
+    public AnthropicResponse sendMessage(
+            String apiKey,
+            String model,
+            int maxTokens,
+            String systemPrompt,
+            String userMessage,
+            String attachmentBase64,
+            String attachmentMimeType) {
+
+        try {
+            List<JsonObject> messages = new ArrayList<>();
+            messages.add(buildUserMessage(userMessage, attachmentBase64, attachmentMimeType));
+
+            JsonArray tools = buildToolsArray();
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(30))
+                    .build();
+
+            long totalInputTokens = 0L;
+            long totalOutputTokens = 0L;
+
+            final long loopDeadlineMs = System.currentTimeMillis() + (5 * 60 * 1000L);
+            final long perRequestMaxMs = 120_000L;
+
+            for (int iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
+                long remainingMs = loopDeadlineMs - System.currentTimeMillis();
+                if (remainingMs <= 0) {
+                    return new AnthropicResponse(
+                            "Request timed out: the agentic loop exceeded the 5-minute deadline.",
+                            totalInputTokens, totalOutputTokens);
+                }
+                long requestTimeoutMs = Math.min(perRequestMaxMs, remainingMs);
+
+                JsonArrayBuilder messagesBuilder = Json.createArrayBuilder();
+                for (JsonObject msg : messages) {
+                    messagesBuilder.add(msg);
+                }
+
+                JsonObject requestBody = Json.createObjectBuilder()
+                        .add("model", model != null ? model : "claude-sonnet-4-6")
+                        .add("max_tokens", maxTokens > 0 ? maxTokens : 4096)
+                        .add("system", systemPrompt != null ? systemPrompt : "")
+                        .add("tools", tools)
+                        .add("messages", messagesBuilder.build())
+                        .build();
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(MESSAGES_ENDPOINT))
+                        .timeout(Duration.ofMillis(requestTimeoutMs))
+                        .header("Content-Type", "application/json")
+                        .header("x-api-key", apiKey)
+                        .header("anthropic-version", ANTHROPIC_VERSION)
+                        .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 200) {
+                    LOG.log(Level.WARNING, "Anthropic API error {0}: {1}",
+                            new Object[]{response.statusCode(), response.body()});
+                    return new AnthropicResponse(
+                            "Error from AI service (HTTP " + response.statusCode() + "): " + response.body(),
+                            totalInputTokens, totalOutputTokens);
+                }
+
+                JsonObject responseJson;
+                try (JsonReader reader = Json.createReader(new StringReader(response.body()))) {
+                    responseJson = reader.readObject();
+                }
+
+                JsonObject usage = responseJson.getJsonObject("usage");
+                if (usage != null) {
+                    totalInputTokens += usage.getInt("input_tokens", 0);
+                    totalOutputTokens += usage.getInt("output_tokens", 0);
+                }
+
+                String stopReason = responseJson.getString("stop_reason", "end_turn");
+                JsonArray contentArray = responseJson.getJsonArray("content");
+
+                if ("end_turn".equals(stopReason) || !"tool_use".equals(stopReason)) {
+                    return new AnthropicResponse(
+                            extractTextFromContent(contentArray),
+                            totalInputTokens, totalOutputTokens);
+                }
+
+                // stop_reason == tool_use: echo assistant turn, then answer each tool call.
+                messages.add(Json.createObjectBuilder()
+                        .add("role", "assistant")
+                        .add("content", contentArray)
+                        .build());
+
+                JsonArrayBuilder toolResultsBuilder = Json.createArrayBuilder();
+                for (int i = 0; i < contentArray.size(); i++) {
+                    JsonObject block = contentArray.getJsonObject(i);
+                    if ("tool_use".equals(block.getString("type", ""))) {
+                        String toolId = block.getString("id", "");
+                        String toolName = block.getString("name", "");
+                        JsonObject toolInput = block.containsKey("input")
+                                ? block.getJsonObject("input")
+                                : Json.createObjectBuilder().build();
+                        String result = executeToolCall(toolName, toolInput);
+                        toolResultsBuilder.add(Json.createObjectBuilder()
+                                .add("type", "tool_result")
+                                .add("tool_use_id", toolId)
+                                .add("content", result));
+                    }
+                }
+                messages.add(Json.createObjectBuilder()
+                        .add("role", "user")
+                        .add("content", toolResultsBuilder.build())
+                        .build());
+            }
+
+            return new AnthropicResponse(
+                    "The AI reached the maximum number of tool-use steps.",
+                    totalInputTokens, totalOutputTokens);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.log(Level.SEVERE, "Anthropic API call interrupted", e);
+            return new AnthropicResponse("Request was interrupted. Please try again.", 0L, 0L);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Error calling Anthropic API", e);
+            return new AnthropicResponse("Error communicating with AI service: " + e.getMessage(), 0L, 0L);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Message / content helpers
+    // -------------------------------------------------------------------------
+
+    private JsonObject buildUserMessage(String userMessage, String attachmentBase64, String attachmentMimeType) {
+        if (attachmentBase64 != null && !attachmentBase64.isEmpty() && attachmentMimeType != null) {
+            JsonArrayBuilder contentBuilder = Json.createArrayBuilder();
+            JsonObject source = Json.createObjectBuilder()
+                    .add("type", "base64")
+                    .add("media_type", attachmentMimeType)
+                    .add("data", attachmentBase64)
+                    .build();
+            if (attachmentMimeType.startsWith("image/")) {
+                contentBuilder.add(Json.createObjectBuilder().add("type", "image").add("source", source));
+            } else {
+                contentBuilder.add(Json.createObjectBuilder().add("type", "document").add("source", source));
+            }
+            if (userMessage != null && !userMessage.trim().isEmpty()) {
+                contentBuilder.add(Json.createObjectBuilder().add("type", "text").add("text", userMessage));
+            }
+            return Json.createObjectBuilder().add("role", "user").add("content", contentBuilder.build()).build();
+        }
+        return Json.createObjectBuilder()
+                .add("role", "user")
+                .add("content", userMessage != null ? userMessage : "")
+                .build();
+    }
+
+    private String extractTextFromContent(JsonArray contentArray) {
+        if (contentArray == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < contentArray.size(); i++) {
+            JsonObject block = contentArray.getJsonObject(i);
+            if ("text".equals(block.getString("type", ""))) {
+                sb.append(block.getString("text", ""));
+            }
+        }
+        return sb.toString();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tools
+    // -------------------------------------------------------------------------
+
+    private JsonArray buildToolsArray() {
+        JsonObject institutionSearch = Json.createObjectBuilder()
+                .add("name", "institution_search")
+                .add("description",
+                        "Search DMIS institutions by name (case-insensitive contains). "
+                        + "Use this to resolve the sending institution printed on a letter to a "
+                        + "real DMIS institution id. Returns id, name, and type for each match.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Institution name or fragment to search for.")))
+                        .add("required", Json.createArrayBuilder().add("query")))
+                .build();
+
+        JsonObject staffSearch = Json.createObjectBuilder()
+                .add("name", "staff_search")
+                .add("description",
+                        "Search DMIS staff/users by name (case-insensitive contains). "
+                        + "Use this to resolve the named sender or signatory of a letter to a real "
+                        + "DMIS user id. Returns id and name for each match.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Person/user name or fragment to search for.")))
+                        .add("required", Json.createArrayBuilder().add("query")))
+                .build();
+
+        return Json.createArrayBuilder().add(institutionSearch).add(staffSearch).build();
+    }
+
+    private String executeToolCall(String toolName, JsonObject toolInput) {
+        try {
+            String query = toolInput.containsKey("query") ? toolInput.getString("query", "") : "";
+            switch (toolName) {
+                case "institution_search":
+                    return searchInstitutions(query);
+                case "staff_search":
+                    return searchStaff(query);
+                default:
+                    return "{\"error\":\"Unknown tool: " + toolName + "\"}";
+            }
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Tool " + toolName + " failed", e);
+            return "{\"error\":\"" + escape(e.getMessage()) + "\"}";
+        }
+    }
+
+    private String searchInstitutions(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            return "{\"results\":[]}";
+        }
+        String jpql = "SELECT i FROM Institution i WHERE i.retired = false "
+                + "AND lower(i.name) LIKE :q ORDER BY i.name";
+        Map<String, Object> params = new HashMap<>();
+        params.put("q", "%" + query.trim().toLowerCase() + "%");
+        List<Institution> matches = institutionFacade.findByJpql(jpql, params, DEFAULT_SEARCH_LIMIT);
+
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (Institution i : matches) {
+            JsonObject o = Json.createObjectBuilder()
+                    .add("id", i.getId())
+                    .add("name", i.getName() != null ? i.getName() : "")
+                    .add("type", i.getInstitutionType() != null ? i.getInstitutionType().toString() : "")
+                    .build();
+            arr.add(o);
+        }
+        return Json.createObjectBuilder().add("results", arr).build().toString();
+    }
+
+    private String searchStaff(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            return "{\"results\":[]}";
+        }
+        String jpql = "SELECT u FROM WebUser u WHERE u.retired = false "
+                + "AND (lower(u.name) LIKE :q OR lower(u.person.name) LIKE :q) ORDER BY u.name";
+        Map<String, Object> params = new HashMap<>();
+        params.put("q", "%" + query.trim().toLowerCase() + "%");
+        List<WebUser> matches = webUserFacade.findByJpql(jpql, params, DEFAULT_SEARCH_LIMIT);
+
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (WebUser u : matches) {
+            String name = u.getPerson() != null && u.getPerson().getName() != null
+                    ? u.getPerson().getName() : u.getName();
+            JsonObject o = Json.createObjectBuilder()
+                    .add("id", u.getId())
+                    .add("name", name != null ? name : "")
+                    .build();
+            arr.add(o);
+        }
+        return Json.createObjectBuilder().add("results", arr).build().toString();
+    }
+
+    private String escape(String s) {
+        return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/CryptoService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/CryptoService.java
@@ -1,0 +1,79 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import javax.ejb.Stateless;
+import org.jasypt.util.text.StrongTextEncryptor;
+
+/**
+ * Reversible encryption for sensitive secrets that must be recovered later
+ * (currently each user's Claude API key).
+ *
+ * <p>Uses Jasypt's {@link StrongTextEncryptor} (PBE with MD5 and TripleDES) —
+ * the same library the application already uses for its other reversible
+ * encryption, but stronger than the legacy {@code BasicTextEncryptor} used for
+ * non-sensitive values.</p>
+ *
+ * <p>The passphrase is resolved, in order, from the system property
+ * {@code dmis.crypto.secret}, then the environment variable
+ * {@code DMIS_CRYPTO_SECRET}, falling back to a built-in default. Operators
+ * should set one of the former in production so secrets are not recoverable
+ * from a database dump alone.</p>
+ */
+@Stateless
+public class CryptoService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String SYSTEM_PROPERTY = "dmis.crypto.secret";
+    private static final String ENV_VARIABLE = "DMIS_CRYPTO_SECRET";
+    private static final String DEFAULT_SECRET = "dmis-default-secret-change-me";
+
+    private StrongTextEncryptor encryptor;
+
+    private StrongTextEncryptor encryptor() {
+        if (encryptor == null) {
+            StrongTextEncryptor e = new StrongTextEncryptor();
+            e.setPassword(resolveSecret());
+            encryptor = e;
+        }
+        return encryptor;
+    }
+
+    private String resolveSecret() {
+        String secret = System.getProperty(SYSTEM_PROPERTY);
+        if (secret == null || secret.trim().isEmpty()) {
+            secret = System.getenv(ENV_VARIABLE);
+        }
+        if (secret == null || secret.trim().isEmpty()) {
+            secret = DEFAULT_SECRET;
+        }
+        return secret;
+    }
+
+    /**
+     * Encrypts the given clear-text value. Returns {@code null} for a
+     * {@code null} input.
+     */
+    public String encrypt(String clearText) {
+        if (clearText == null) {
+            return null;
+        }
+        return encryptor().encrypt(clearText);
+    }
+
+    /**
+     * Decrypts a value previously produced by {@link #encrypt(String)}. Returns
+     * {@code null} for a {@code null} input.
+     */
+    public String decrypt(String cipherText) {
+        if (cipherText == null) {
+            return null;
+        }
+        return encryptor().decrypt(cipherText);
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/LetterExtractionService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/LetterExtractionService.java
@@ -1,0 +1,170 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import java.io.StringReader;
+import java.util.Base64;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+import lk.gov.health.phsp.pojcs.AnthropicResponse;
+import lk.gov.health.phsp.pojcs.LetterExtractionResult;
+
+/**
+ * Turns a single-letter PDF segment into structured {@link LetterExtractionResult}
+ * metadata by asking Claude to OCR it and resolve the sending institution /
+ * signatory against DMIS via the {@link AnthropicApiService} grounding tools.
+ */
+@Stateless
+public class LetterExtractionService implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(LetterExtractionService.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    private static final int MAX_TOKENS = 2048;
+
+    private static final String SYSTEM_PROMPT =
+            "You extract registry metadata from a SINGLE scanned letter supplied as a PDF. "
+            + "Sri Lankan government letters may be in Sinhala, Tamil, or English. "
+            + "OCR the letter, then resolve names to DMIS records:\n"
+            + "- Call institution_search to find the id of the SENDING institution (the one that "
+            + "issued the letter, usually in the letterhead).\n"
+            + "- Call staff_search to find the id of the named signatory/sender if a person is named.\n"
+            + "Only set a resolved id when a returned match is clearly the same entity; otherwise leave it null.\n\n"
+            + "Respond with ONLY a single JSON object (no markdown, no commentary) with exactly these keys:\n"
+            + "{\n"
+            + "  \"subject\": string,                 // letter subject/title, or a short summary\n"
+            + "  \"letterDate\": string|null,         // date on the letter as yyyy-MM-dd, else null\n"
+            + "  \"senderInstitutionName\": string|null,\n"
+            + "  \"resolvedInstitutionId\": number|null,\n"
+            + "  \"senderName\": string|null,\n"
+            + "  \"resolvedStaffId\": number|null,\n"
+            + "  \"registrationNo\": string|null,     // sender's outgoing/reference number if printed\n"
+            + "  \"referenceNo\": string|null,        // any 'your reference' number if printed\n"
+            + "  \"confidence\": number               // 0..1, your confidence in this extraction\n"
+            + "}";
+
+    @EJB
+    private AnthropicApiService anthropicApiService;
+
+    /**
+     * Extracts metadata from one letter segment. Never throws: on any failure a
+     * result with {@code errorMessage} set is returned so the reviewer can fill
+     * the fields manually.
+     *
+     * @param subPdfBytes a standalone PDF containing only this letter's pages
+     * @param apiKey      the user's Claude API key
+     * @param model       Claude model id (or null for the service default)
+     */
+    public LetterExtractionResult extractFromSegment(byte[] subPdfBytes, String apiKey, String model) {
+        LetterExtractionResult result = new LetterExtractionResult();
+        if (subPdfBytes == null || subPdfBytes.length == 0) {
+            result.setErrorMessage("Empty PDF segment.");
+            return result;
+        }
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            result.setErrorMessage("No Claude API key configured for this user.");
+            return result;
+        }
+        try {
+            String base64 = Base64.getEncoder().encodeToString(subPdfBytes);
+            AnthropicResponse response = anthropicApiService.sendMessage(
+                    apiKey, model, MAX_TOKENS, SYSTEM_PROMPT,
+                    "Extract the metadata for this letter as specified.",
+                    base64, "application/pdf");
+
+            result.setInputTokens(response.getInputTokens());
+            result.setOutputTokens(response.getOutputTokens());
+
+            String content = response.getContent();
+            result.setRawJson(content);
+            parseInto(content, result);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Letter extraction failed", e);
+            result.setErrorMessage("Extraction failed: " + e.getMessage());
+        }
+        return result;
+    }
+
+    private void parseInto(String content, LetterExtractionResult result) {
+        String json = stripToJson(content);
+        if (json == null) {
+            result.setErrorMessage("Claude did not return JSON. Raw: "
+                    + (content == null ? "null" : truncate(content)));
+            return;
+        }
+        try (JsonReader reader = Json.createReader(new StringReader(json))) {
+            JsonObject obj = reader.readObject();
+            result.setSubject(getString(obj, "subject"));
+            result.setLetterDate(getString(obj, "letterDate"));
+            result.setSenderInstitutionName(getString(obj, "senderInstitutionName"));
+            result.setResolvedInstitutionId(getLong(obj, "resolvedInstitutionId"));
+            result.setSenderName(getString(obj, "senderName"));
+            result.setResolvedStaffId(getLong(obj, "resolvedStaffId"));
+            result.setRegistrationNo(getString(obj, "registrationNo"));
+            result.setReferenceNo(getString(obj, "referenceNo"));
+            if (obj.containsKey("confidence") && !obj.isNull("confidence")) {
+                try {
+                    result.setConfidence(obj.getJsonNumber("confidence").doubleValue());
+                } catch (Exception ignore) {
+                    // leave confidence at 0
+                }
+            }
+        } catch (Exception e) {
+            result.setErrorMessage("Could not parse Claude JSON: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Extracts the first {@code { ... }} JSON object from Claude's text,
+     * tolerating ```json fences or stray prose around it.
+     */
+    private String stripToJson(String content) {
+        if (content == null) {
+            return null;
+        }
+        int start = content.indexOf('{');
+        int end = content.lastIndexOf('}');
+        if (start < 0 || end < 0 || end <= start) {
+            return null;
+        }
+        return content.substring(start, end + 1);
+    }
+
+    private String getString(JsonObject obj, String key) {
+        if (!obj.containsKey(key) || obj.isNull(key)) {
+            return null;
+        }
+        try {
+            return obj.getString(key);
+        } catch (Exception e) {
+            // value present but not a string
+            JsonValue v = obj.get(key);
+            return v != null ? v.toString() : null;
+        }
+    }
+
+    private Long getLong(JsonObject obj, String key) {
+        if (!obj.containsKey(key) || obj.isNull(key)) {
+            return null;
+        }
+        try {
+            return obj.getJsonNumber(key).longValue();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String truncate(String s) {
+        return s.length() > 300 ? s.substring(0, 300) + "..." : s;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/LetterImportCleanupBean.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/LetterImportCleanupBean.java
@@ -1,0 +1,79 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Schedule;
+import javax.ejb.Singleton;
+import lk.gov.health.phsp.entity.LetterImportBatch;
+import lk.gov.health.phsp.entity.LetterImportItem;
+import lk.gov.health.phsp.facade.LetterImportBatchFacade;
+import lk.gov.health.phsp.facade.LetterImportItemFacade;
+
+/**
+ * Periodically purges old letter-import batches (and their items) so the
+ * temporarily-held PDF blobs and rendered previews do not accumulate. Runs a
+ * few times a day; retention is governed by {@link LetterImportConfig}.
+ */
+@Singleton
+public class LetterImportCleanupBean implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(LetterImportCleanupBean.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private LetterImportBatchFacade batchFacade;
+    @EJB
+    private LetterImportItemFacade itemFacade;
+    @EJB
+    private LetterImportConfig config;
+
+    /** Runs every 6 hours; not persistent so it never queues missed runs. */
+    @Schedule(hour = "*/6", minute = "0", second = "0", persistent = false)
+    public void purgeOldBatches() {
+        try {
+            int retentionDays = config.getRetentionDays();
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.DAY_OF_MONTH, -Math.max(1, retentionDays));
+            Date cutoff = cal.getTime();
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("cutoff", cutoff);
+            List<LetterImportBatch> old = batchFacade.findByJpql(
+                    "SELECT b FROM LetterImportBatch b WHERE b.createdAt < :cutoff",
+                    params, javax.persistence.TemporalType.TIMESTAMP);
+
+            int batches = 0;
+            int items = 0;
+            for (LetterImportBatch batch : old) {
+                Map<String, Object> ip = new HashMap<>();
+                ip.put("b", batch);
+                List<LetterImportItem> children = itemFacade.findByJpql(
+                        "SELECT i FROM LetterImportItem i WHERE i.batch = :b", ip);
+                for (LetterImportItem item : children) {
+                    itemFacade.remove(item);
+                    items++;
+                }
+                batchFacade.remove(batch);
+                batches++;
+            }
+            if (batches > 0) {
+                LOG.log(Level.INFO, "Letter-import cleanup removed {0} batches and {1} items older than {2} days",
+                        new Object[]{batches, items, retentionDays});
+            }
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Letter-import cleanup failed", e);
+        }
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/LetterImportConfig.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/LetterImportConfig.java
@@ -1,0 +1,79 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import javax.ejb.Stateless;
+
+/**
+ * Tunable settings for the letter-import feature.
+ *
+ * <p>DMIS has no application ConfigOption store, so each value is resolved from
+ * a JVM system property, then an environment variable, then a built-in default.
+ * This keeps operators in control without a new configuration UI.</p>
+ *
+ * <table>
+ *   <tr><th>Setting</th><th>System property</th><th>Env var</th><th>Default</th></tr>
+ *   <tr><td>Default Claude model</td><td>dmis.letterImport.model</td><td>DMIS_LETTER_IMPORT_MODEL</td><td>claude-sonnet-4-6</td></tr>
+ *   <tr><td>Blank-page threshold</td><td>dmis.letterImport.blankThreshold</td><td>DMIS_LETTER_IMPORT_BLANK_THRESHOLD</td><td>0.005</td></tr>
+ *   <tr><td>Render DPI</td><td>dmis.letterImport.renderDpi</td><td>DMIS_LETTER_IMPORT_RENDER_DPI</td><td>150</td></tr>
+ *   <tr><td>Max pages per PDF</td><td>dmis.letterImport.maxPages</td><td>DMIS_LETTER_IMPORT_MAX_PAGES</td><td>500</td></tr>
+ *   <tr><td>Batch retention days</td><td>dmis.letterImport.retentionDays</td><td>DMIS_LETTER_IMPORT_RETENTION_DAYS</td><td>7</td></tr>
+ * </table>
+ */
+@Stateless
+public class LetterImportConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public String getDefaultModel() {
+        return resolve("dmis.letterImport.model", "DMIS_LETTER_IMPORT_MODEL", "claude-sonnet-4-6");
+    }
+
+    public double getBlankThreshold() {
+        return resolveDouble("dmis.letterImport.blankThreshold",
+                "DMIS_LETTER_IMPORT_BLANK_THRESHOLD", PdfSplitService.DEFAULT_BLANK_THRESHOLD);
+    }
+
+    public int getRenderDpi() {
+        return resolveInt("dmis.letterImport.renderDpi",
+                "DMIS_LETTER_IMPORT_RENDER_DPI", PdfSplitService.DEFAULT_RENDER_DPI);
+    }
+
+    public int getMaxPages() {
+        return resolveInt("dmis.letterImport.maxPages", "DMIS_LETTER_IMPORT_MAX_PAGES", 500);
+    }
+
+    public int getRetentionDays() {
+        return resolveInt("dmis.letterImport.retentionDays", "DMIS_LETTER_IMPORT_RETENTION_DAYS", 7);
+    }
+
+    // -------------------------------------------------------------------------
+
+    private String resolve(String systemProperty, String envVar, String fallback) {
+        String value = System.getProperty(systemProperty);
+        if (value == null || value.trim().isEmpty()) {
+            value = System.getenv(envVar);
+        }
+        return value != null && !value.trim().isEmpty() ? value.trim() : fallback;
+    }
+
+    private int resolveInt(String systemProperty, String envVar, int fallback) {
+        try {
+            return Integer.parseInt(resolve(systemProperty, envVar, Integer.toString(fallback)));
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private double resolveDouble(String systemProperty, String envVar, double fallback) {
+        try {
+            return Double.parseDouble(resolve(systemProperty, envVar, Double.toString(fallback)));
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/LetterImportService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/LetterImportService.java
@@ -1,0 +1,174 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.Asynchronous;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import lk.gov.health.phsp.entity.Institution;
+import lk.gov.health.phsp.entity.LetterImportBatch;
+import lk.gov.health.phsp.entity.LetterImportItem;
+import lk.gov.health.phsp.entity.WebUser;
+import lk.gov.health.phsp.enums.LetterImportItemStatus;
+import lk.gov.health.phsp.facade.InstitutionFacade;
+import lk.gov.health.phsp.facade.LetterImportBatchFacade;
+import lk.gov.health.phsp.facade.WebUserFacade;
+import lk.gov.health.phsp.pojcs.LetterExtractionResult;
+import lk.gov.health.phsp.pojcs.PageRange;
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+/**
+ * Background orchestration of a letter-import batch: split the uploaded PDF into
+ * per-letter segments, render a preview, ask Claude to OCR + extract metadata,
+ * and persist one {@code LetterImportItem} per letter for review.
+ *
+ * <p>The orchestration method runs {@link Asynchronous} and
+ * {@link TransactionAttributeType#NOT_SUPPORTED} (no long-lived transaction);
+ * all writes are delegated to {@link LetterImportTxBean} so each commits on its
+ * own and the review UI can poll progress.</p>
+ */
+@Stateless
+public class LetterImportService implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(LetterImportService.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private LetterImportBatchFacade batchFacade;
+    @EJB
+    private InstitutionFacade institutionFacade;
+    @EJB
+    private WebUserFacade webUserFacade;
+    @EJB
+    private PdfSplitService pdfSplitService;
+    @EJB
+    private LetterExtractionService letterExtractionService;
+    @EJB
+    private LetterImportTxBean txBean;
+
+    /**
+     * Processes a batch end to end. Never propagates exceptions: failures mark
+     * the batch FAILED so the UI can surface them.
+     *
+     * @param batchId the batch to process
+     * @param apiKey  the owner's decrypted Claude key (resolved by the caller)
+     * @param model   Claude model id, or null for the service default
+     */
+    @Asynchronous
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void processBatch(Long batchId, String apiKey, String model) {
+        LetterImportBatch batch = batchFacade.find(batchId);
+        if (batch == null) {
+            LOG.log(Level.WARNING, "Letter import batch {0} not found", batchId);
+            return;
+        }
+        byte[] pdf = batch.getPdfBytes();
+        try {
+            List<PageRange> segments = pdfSplitService.detectSegments(pdf);
+            int pageCount = countPages(pdf);
+            txBean.markProcessing(batchId, pageCount, segments.size());
+
+            int index = 0;
+            for (PageRange range : segments) {
+                LetterImportItem item = processSegment(batch, range, index, apiKey, model);
+                txBean.saveItem(item);
+                txBean.recordProgress(batchId,
+                        item.getInputTokens() != null ? item.getInputTokens() : 0L,
+                        item.getOutputTokens() != null ? item.getOutputTokens() : 0L);
+                index++;
+            }
+            txBean.markReady(batchId);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed processing letter import batch " + batchId, e);
+            txBean.markFailed(batchId, e.getMessage());
+        }
+    }
+
+    private LetterImportItem processSegment(LetterImportBatch batch, PageRange range,
+            int index, String apiKey, String model) {
+        LetterImportItem item = new LetterImportItem();
+        item.setBatch(batch);
+        item.setSegmentIndex(index);
+        item.setStartPage(range.getStart());
+        item.setEndPage(range.getEnd());
+        item.setStatus(LetterImportItemStatus.PENDING);
+        item.setReceivedDate(new Date()); // stamp date defaults to today
+
+        byte[] pdf = batch.getPdfBytes();
+        try {
+            item.setPreviewImage(pdfSplitService.renderPageToPng(pdf, range.getStart()));
+            item.setPreviewContentType("image/png");
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Preview render failed for segment " + index, e);
+        }
+
+        try {
+            byte[] subPdf = pdfSplitService.extractSubPdf(pdf, range.getStart(), range.getEnd());
+            LetterExtractionResult extraction =
+                    letterExtractionService.extractFromSegment(subPdf, apiKey, model);
+            applyExtraction(item, extraction);
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Extraction failed for segment " + index, e);
+            item.setErrorMessage("Extraction failed: " + e.getMessage());
+        }
+        return item;
+    }
+
+    private void applyExtraction(LetterImportItem item, LetterExtractionResult extraction) {
+        if (extraction == null) {
+            return;
+        }
+        item.setRawJson(extraction.getRawJson());
+        item.setConfidence(extraction.getConfidence());
+        item.setInputTokens(extraction.getInputTokens());
+        item.setOutputTokens(extraction.getOutputTokens());
+        if (extraction.isFailed()) {
+            item.setErrorMessage(extraction.getErrorMessage());
+        } else {
+            item.setSubject(extraction.getSubject());
+            item.setLetterDate(parseDate(extraction.getLetterDate()));
+            item.setSenderName(extraction.getSenderName());
+            item.setRegistrationNo(extraction.getRegistrationNo());
+            item.setReferenceNo(extraction.getReferenceNo());
+            if (extraction.getResolvedInstitutionId() != null) {
+                Institution ins = institutionFacade.find(extraction.getResolvedInstitutionId());
+                item.setResolvedInstitution(ins);
+            }
+            if (extraction.getResolvedStaffId() != null) {
+                WebUser staff = webUserFacade.find(extraction.getResolvedStaffId());
+                item.setResolvedStaff(staff);
+            }
+        }
+    }
+
+    private Date parseDate(String iso) {
+        if (iso == null || iso.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd").parse(iso.trim());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private int countPages(byte[] pdf) {
+        try (PDDocument document = PDDocument.load(new ByteArrayInputStream(pdf))) {
+            return document.getNumberOfPages();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/LetterImportService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/LetterImportService.java
@@ -57,6 +57,8 @@ public class LetterImportService implements Serializable {
     private LetterExtractionService letterExtractionService;
     @EJB
     private LetterImportTxBean txBean;
+    @EJB
+    private LetterImportConfig config;
 
     /**
      * Processes a batch end to end. Never propagates exceptions: failures mark
@@ -75,14 +77,22 @@ public class LetterImportService implements Serializable {
             return;
         }
         byte[] pdf = batch.getPdfBytes();
+        String effectiveModel = (model != null && !model.trim().isEmpty())
+                ? model : config.getDefaultModel();
         try {
-            List<PageRange> segments = pdfSplitService.detectSegments(pdf);
             int pageCount = countPages(pdf);
+            int maxPages = config.getMaxPages();
+            if (pageCount > maxPages) {
+                txBean.markFailed(batchId, "PDF has " + pageCount + " pages, exceeding the "
+                        + maxPages + "-page limit. Split it into smaller files.");
+                return;
+            }
+            List<PageRange> segments = pdfSplitService.detectSegments(pdf, config.getBlankThreshold());
             txBean.markProcessing(batchId, pageCount, segments.size());
 
             int index = 0;
             for (PageRange range : segments) {
-                LetterImportItem item = processSegment(batch, range, index, apiKey, model);
+                LetterImportItem item = processSegment(batch, range, index, apiKey, effectiveModel);
                 txBean.saveItem(item);
                 txBean.recordProgress(batchId,
                         item.getInputTokens() != null ? item.getInputTokens() : 0L,
@@ -108,7 +118,7 @@ public class LetterImportService implements Serializable {
 
         byte[] pdf = batch.getPdfBytes();
         try {
-            item.setPreviewImage(pdfSplitService.renderPageToPng(pdf, range.getStart()));
+            item.setPreviewImage(pdfSplitService.renderPageToPng(pdf, range.getStart(), config.getRenderDpi()));
             item.setPreviewContentType("image/png");
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Preview render failed for segment " + index, e);

--- a/src/main/java/lk/gov/health/phsp/ejb/LetterImportTxBean.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/LetterImportTxBean.java
@@ -1,0 +1,93 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import lk.gov.health.phsp.entity.LetterImportBatch;
+import lk.gov.health.phsp.entity.LetterImportItem;
+import lk.gov.health.phsp.enums.LetterImportStatus;
+import lk.gov.health.phsp.facade.LetterImportBatchFacade;
+import lk.gov.health.phsp.facade.LetterImportItemFacade;
+
+/**
+ * Short, independent ({@link TransactionAttributeType#REQUIRES_NEW}) database
+ * writes used by the long-running, transaction-less {@code LetterImportService}
+ * orchestration. Each method commits on its own so the polling review UI sees
+ * progress as letters are processed, and so a slow Claude call never holds a
+ * transaction open.
+ */
+@Stateless
+public class LetterImportTxBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private LetterImportBatchFacade batchFacade;
+    @EJB
+    private LetterImportItemFacade itemFacade;
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void markProcessing(Long batchId, int pageCount, int letterCount) {
+        LetterImportBatch batch = batchFacade.find(batchId);
+        if (batch == null) {
+            return;
+        }
+        batch.setStatus(LetterImportStatus.PROCESSING);
+        batch.setPageCount(pageCount);
+        batch.setLetterCount(letterCount);
+        batch.setProcessedCount(0);
+        batch.setTotalInputTokens(0L);
+        batch.setTotalOutputTokens(0L);
+        batchFacade.edit(batch);
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void saveItem(LetterImportItem item) {
+        item.setCreatedAt(new Date());
+        itemFacade.create(item);
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void recordProgress(Long batchId, long addInputTokens, long addOutputTokens) {
+        LetterImportBatch batch = batchFacade.find(batchId);
+        if (batch == null) {
+            return;
+        }
+        int processed = batch.getProcessedCount() != null ? batch.getProcessedCount() : 0;
+        long in = batch.getTotalInputTokens() != null ? batch.getTotalInputTokens() : 0L;
+        long out = batch.getTotalOutputTokens() != null ? batch.getTotalOutputTokens() : 0L;
+        batch.setProcessedCount(processed + 1);
+        batch.setTotalInputTokens(in + addInputTokens);
+        batch.setTotalOutputTokens(out + addOutputTokens);
+        batchFacade.edit(batch);
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void markReady(Long batchId) {
+        LetterImportBatch batch = batchFacade.find(batchId);
+        if (batch == null) {
+            return;
+        }
+        batch.setStatus(LetterImportStatus.READY);
+        batchFacade.edit(batch);
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void markFailed(Long batchId, String error) {
+        LetterImportBatch batch = batchFacade.find(batchId);
+        if (batch == null) {
+            return;
+        }
+        batch.setStatus(LetterImportStatus.FAILED);
+        batch.setErrorMessage(error);
+        batchFacade.edit(batch);
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/ejb/PdfSplitService.java
+++ b/src/main/java/lk/gov/health/phsp/ejb/PdfSplitService.java
@@ -1,0 +1,173 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.ejb;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ejb.Stateless;
+import javax.imageio.ImageIO;
+import lk.gov.health.phsp.pojcs.PageRange;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+/**
+ * Local (no external service) PDF processing for the letter-import feature.
+ *
+ * <p>Users upload a single PDF in which individual letters are separated by
+ * blank pages. This service detects those blank separator pages, groups the
+ * remaining pages into per-letter {@link PageRange} segments, extracts a
+ * per-letter sub-PDF (to hand to Claude as a {@code document} block), and
+ * rasterizes pages to PNG (to store as letter attachments).</p>
+ *
+ * <p>Blank detection is done by rasterizing each page at a low DPI and
+ * measuring the fraction of "ink" (dark) pixels. This works for scanned,
+ * image-only PDFs that have no text layer, which a text-based check would
+ * miss.</p>
+ */
+@Stateless
+public class PdfSplitService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** DPI used for the cheap blank-detection render. */
+    private static final int DETECTION_DPI = 50;
+
+    /** Luminance (0-255) below which a pixel is counted as ink. */
+    private static final int INK_LUMINANCE_THRESHOLD = 128;
+
+    /**
+     * Default maximum fraction of ink pixels for a page to count as blank.
+     * A speckle-free blank page is ~0; scanned blanks carry a little noise,
+     * so a small non-zero default is used.
+     */
+    public static final double DEFAULT_BLANK_THRESHOLD = 0.005;
+
+    /** Default DPI for the stored letter image render. */
+    public static final int DEFAULT_RENDER_DPI = 150;
+
+    /**
+     * Detects per-letter page ranges using the default blank threshold.
+     */
+    public List<PageRange> detectSegments(byte[] pdfBytes) throws IOException {
+        return detectSegments(pdfBytes, DEFAULT_BLANK_THRESHOLD);
+    }
+
+    /**
+     * Detects per-letter page ranges by treating blank pages as separators.
+     *
+     * <p>Leading, trailing, and consecutive blank pages are ignored; each run
+     * of consecutive non-blank pages becomes one {@link PageRange}. If no blank
+     * pages are found, the whole document is returned as a single range.</p>
+     *
+     * @param pdfBytes       the uploaded PDF
+     * @param blankThreshold maximum ink fraction (0..1) for a page to be blank
+     * @return ordered, non-overlapping letter ranges (possibly empty)
+     */
+    public List<PageRange> detectSegments(byte[] pdfBytes, double blankThreshold) throws IOException {
+        List<PageRange> ranges = new ArrayList<>();
+        if (pdfBytes == null || pdfBytes.length == 0) {
+            return ranges;
+        }
+        try (PDDocument document = PDDocument.load(new ByteArrayInputStream(pdfBytes))) {
+            int pageCount = document.getNumberOfPages();
+            PDFRenderer renderer = new PDFRenderer(document);
+
+            int segmentStart = -1;
+            for (int i = 0; i < pageCount; i++) {
+                boolean blank = isPageBlank(renderer, i, blankThreshold);
+                if (blank) {
+                    if (segmentStart >= 0) {
+                        ranges.add(new PageRange(segmentStart, i - 1));
+                        segmentStart = -1;
+                    }
+                } else if (segmentStart < 0) {
+                    segmentStart = i;
+                }
+            }
+            if (segmentStart >= 0) {
+                ranges.add(new PageRange(segmentStart, pageCount - 1));
+            }
+        }
+        return ranges;
+    }
+
+    /**
+     * Renders a single page to grayscale at low DPI and returns the fraction of
+     * dark (ink) pixels, comparing it against {@code blankThreshold}.
+     */
+    private boolean isPageBlank(PDFRenderer renderer, int pageIndex, double blankThreshold) throws IOException {
+        BufferedImage image = renderer.renderImageWithDPI(pageIndex, DETECTION_DPI, ImageType.GRAY);
+        int width = image.getWidth();
+        int height = image.getHeight();
+        long totalPixels = (long) width * height;
+        if (totalPixels == 0) {
+            return true;
+        }
+        long inkPixels = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                // GRAY image: the low byte of the RGB int is the luminance.
+                int luminance = image.getRGB(x, y) & 0xFF;
+                if (luminance < INK_LUMINANCE_THRESHOLD) {
+                    inkPixels++;
+                }
+            }
+        }
+        double inkFraction = (double) inkPixels / (double) totalPixels;
+        return inkFraction <= blankThreshold;
+    }
+
+    /**
+     * Extracts the given inclusive, zero-based page range into a standalone PDF.
+     *
+     * @return the bytes of a new PDF containing only those pages
+     */
+    public byte[] extractSubPdf(byte[] pdfBytes, int startPage, int endPage) throws IOException {
+        try (PDDocument source = PDDocument.load(new ByteArrayInputStream(pdfBytes));
+             PDDocument target = new PDDocument()) {
+            int pageCount = source.getNumberOfPages();
+            int from = Math.max(0, startPage);
+            int to = Math.min(pageCount - 1, endPage);
+            for (int i = from; i <= to; i++) {
+                PDPage imported = target.importPage(source.getPage(i));
+                // importPage clones structure; nothing else required.
+                if (imported == null) {
+                    throw new IOException("Failed to import page " + i);
+                }
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            target.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    /**
+     * Rasterizes a single page to PNG at the default render DPI.
+     */
+    public byte[] renderPageToPng(byte[] pdfBytes, int pageIndex) throws IOException {
+        return renderPageToPng(pdfBytes, pageIndex, DEFAULT_RENDER_DPI);
+    }
+
+    /**
+     * Rasterizes a single zero-based page to PNG at the given DPI.
+     */
+    public byte[] renderPageToPng(byte[] pdfBytes, int pageIndex, int dpi) throws IOException {
+        try (PDDocument document = PDDocument.load(new ByteArrayInputStream(pdfBytes))) {
+            PDFRenderer renderer = new PDFRenderer(document);
+            BufferedImage image = renderer.renderImageWithDPI(pageIndex, dpi, ImageType.RGB);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", out);
+            return out.toByteArray();
+        }
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/entity/LetterImportBatch.java
+++ b/src/main/java/lk/gov/health/phsp/entity/LetterImportBatch.java
@@ -1,0 +1,141 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import lk.gov.health.phsp.enums.LetterImportStatus;
+
+/**
+ * A temporarily-held upload of a multi-letter PDF (individual letters separated
+ * by blank pages) being processed by the letter-import feature. Holds the raw
+ * PDF and aggregate processing state; per-letter proposals live in
+ * {@code LetterImportItem}. Old batches are purged by a scheduled cleanup.
+ */
+@Entity
+@Table(name = "letter_import_batch")
+public class LetterImportBatch implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    /** The user who uploaded the PDF (and whose Claude key is used). */
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser owner;
+
+    /** Logged institution context, used when creating the resulting letters. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution institution;
+
+    private String originalFileName;
+
+    /** The uploaded PDF, held until the batch is reviewed and purged. */
+    @Lob
+    @Column(columnDefinition = "LONGBLOB")
+    private byte[] pdfBytes;
+
+    @Enumerated(EnumType.STRING)
+    private LetterImportStatus status;
+
+    private Integer pageCount;
+    /** Number of detected letters (segments). */
+    private Integer letterCount;
+    /** Number of letters processed so far (for progress display). */
+    private Integer processedCount;
+
+    private String model;
+    private Long totalInputTokens;
+    private Long totalOutputTokens;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser createdBy;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    private boolean retired;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser retiredBy;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    private String retireComments;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public WebUser getOwner() { return owner; }
+    public void setOwner(WebUser owner) { this.owner = owner; }
+
+    public Institution getInstitution() { return institution; }
+    public void setInstitution(Institution institution) { this.institution = institution; }
+
+    public String getOriginalFileName() { return originalFileName; }
+    public void setOriginalFileName(String originalFileName) { this.originalFileName = originalFileName; }
+
+    public byte[] getPdfBytes() { return pdfBytes; }
+    public void setPdfBytes(byte[] pdfBytes) { this.pdfBytes = pdfBytes; }
+
+    public LetterImportStatus getStatus() { return status; }
+    public void setStatus(LetterImportStatus status) { this.status = status; }
+
+    public Integer getPageCount() { return pageCount; }
+    public void setPageCount(Integer pageCount) { this.pageCount = pageCount; }
+
+    public Integer getLetterCount() { return letterCount; }
+    public void setLetterCount(Integer letterCount) { this.letterCount = letterCount; }
+
+    public Integer getProcessedCount() { return processedCount; }
+    public void setProcessedCount(Integer processedCount) { this.processedCount = processedCount; }
+
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
+
+    public Long getTotalInputTokens() { return totalInputTokens; }
+    public void setTotalInputTokens(Long totalInputTokens) { this.totalInputTokens = totalInputTokens; }
+
+    public Long getTotalOutputTokens() { return totalOutputTokens; }
+    public void setTotalOutputTokens(Long totalOutputTokens) { this.totalOutputTokens = totalOutputTokens; }
+
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
+    public WebUser getCreatedBy() { return createdBy; }
+    public void setCreatedBy(WebUser createdBy) { this.createdBy = createdBy; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public boolean isRetired() { return retired; }
+    public void setRetired(boolean retired) { this.retired = retired; }
+
+    public WebUser getRetiredBy() { return retiredBy; }
+    public void setRetiredBy(WebUser retiredBy) { this.retiredBy = retiredBy; }
+
+    public Date getRetiredAt() { return retiredAt; }
+    public void setRetiredAt(Date retiredAt) { this.retiredAt = retiredAt; }
+
+    public String getRetireComments() { return retireComments; }
+    public void setRetireComments(String retireComments) { this.retireComments = retireComments; }
+}

--- a/src/main/java/lk/gov/health/phsp/entity/LetterImportItem.java
+++ b/src/main/java/lk/gov/health/phsp/entity/LetterImportItem.java
@@ -1,0 +1,168 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import lk.gov.health.phsp.enums.LetterImportItemStatus;
+
+/**
+ * One detected letter within a {@code LetterImportBatch}: its page range, the
+ * metadata Claude proposed (editable by the reviewer), a rendered preview
+ * image, and — once accepted — a link to the created {@code Document} letter.
+ */
+@Entity
+@Table(name = "letter_import_item")
+public class LetterImportItem implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private LetterImportBatch batch;
+
+    /** Order of this letter within the batch (0-based). */
+    private Integer segmentIndex;
+    /** Zero-based inclusive page range within the batch PDF. */
+    private Integer startPage;
+    private Integer endPage;
+
+    @Enumerated(EnumType.STRING)
+    private LetterImportItemStatus status;
+
+    // --- Proposed / edited metadata ---------------------------------------
+    private String subject;
+    @Temporal(TemporalType.DATE)
+    private Date letterDate;
+    /** Stamp/received date; defaults to today in the review UI. */
+    @Temporal(TemporalType.DATE)
+    private Date receivedDate;
+    private String senderName;
+    private String registrationNo;
+    private String referenceNo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution resolvedInstitution;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser resolvedStaff;
+
+    private Double confidence;
+
+    private Long inputTokens;
+    private Long outputTokens;
+
+    /** Rendered preview image of the first page of this letter. */
+    @Lob
+    @Column(columnDefinition = "LONGBLOB")
+    private byte[] previewImage;
+    private String previewContentType;
+
+    /** Raw JSON Claude returned, for auditing. */
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String rawJson;
+
+    /** Set once the reviewer accepts and a letter is created. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Document createdDocument;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date decidedAt;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public LetterImportBatch getBatch() { return batch; }
+    public void setBatch(LetterImportBatch batch) { this.batch = batch; }
+
+    public Integer getSegmentIndex() { return segmentIndex; }
+    public void setSegmentIndex(Integer segmentIndex) { this.segmentIndex = segmentIndex; }
+
+    public Integer getStartPage() { return startPage; }
+    public void setStartPage(Integer startPage) { this.startPage = startPage; }
+
+    public Integer getEndPage() { return endPage; }
+    public void setEndPage(Integer endPage) { this.endPage = endPage; }
+
+    public LetterImportItemStatus getStatus() { return status; }
+    public void setStatus(LetterImportItemStatus status) { this.status = status; }
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+
+    public Date getLetterDate() { return letterDate; }
+    public void setLetterDate(Date letterDate) { this.letterDate = letterDate; }
+
+    public Date getReceivedDate() { return receivedDate; }
+    public void setReceivedDate(Date receivedDate) { this.receivedDate = receivedDate; }
+
+    public String getSenderName() { return senderName; }
+    public void setSenderName(String senderName) { this.senderName = senderName; }
+
+    public String getRegistrationNo() { return registrationNo; }
+    public void setRegistrationNo(String registrationNo) { this.registrationNo = registrationNo; }
+
+    public String getReferenceNo() { return referenceNo; }
+    public void setReferenceNo(String referenceNo) { this.referenceNo = referenceNo; }
+
+    public Institution getResolvedInstitution() { return resolvedInstitution; }
+    public void setResolvedInstitution(Institution resolvedInstitution) { this.resolvedInstitution = resolvedInstitution; }
+
+    public WebUser getResolvedStaff() { return resolvedStaff; }
+    public void setResolvedStaff(WebUser resolvedStaff) { this.resolvedStaff = resolvedStaff; }
+
+    public Double getConfidence() { return confidence; }
+    public void setConfidence(Double confidence) { this.confidence = confidence; }
+
+    public Long getInputTokens() { return inputTokens; }
+    public void setInputTokens(Long inputTokens) { this.inputTokens = inputTokens; }
+
+    public Long getOutputTokens() { return outputTokens; }
+    public void setOutputTokens(Long outputTokens) { this.outputTokens = outputTokens; }
+
+    public byte[] getPreviewImage() { return previewImage; }
+    public void setPreviewImage(byte[] previewImage) { this.previewImage = previewImage; }
+
+    public String getPreviewContentType() { return previewContentType; }
+    public void setPreviewContentType(String previewContentType) { this.previewContentType = previewContentType; }
+
+    public String getRawJson() { return rawJson; }
+    public void setRawJson(String rawJson) { this.rawJson = rawJson; }
+
+    public Document getCreatedDocument() { return createdDocument; }
+    public void setCreatedDocument(Document createdDocument) { this.createdDocument = createdDocument; }
+
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public Date getDecidedAt() { return decidedAt; }
+    public void setDecidedAt(Date decidedAt) { this.decidedAt = decidedAt; }
+}

--- a/src/main/java/lk/gov/health/phsp/entity/UserClaudeApiKey.java
+++ b/src/main/java/lk/gov/health/phsp/entity/UserClaudeApiKey.java
@@ -1,0 +1,111 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * A user's personal Claude (Anthropic) API key, used by the letter-import
+ * feature so each user is billed on their own key rather than an
+ * application-wide one.
+ *
+ * <p>The raw key is <strong>never</strong> stored in clear text: only the
+ * encrypted form ({@link #encryptedKey}) and a short, non-sensitive hint
+ * ({@link #last4}) for display are persisted. At most one non-retired record
+ * per {@link #owner} should be {@link #active}.</p>
+ */
+@Entity
+@Table(name = "user_claude_api_key")
+public class UserClaudeApiKey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser owner;
+
+    /** Encrypted Claude API key (see CryptoService). Never the raw value. */
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String encryptedKey;
+
+    /** Last 4 characters of the raw key, kept only for masked display. */
+    @Column(length = 8)
+    private String last4;
+
+    /** Optional per-user Claude model override (else the configured default). */
+    private String modelOverride;
+
+    private boolean active;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser createdBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    private boolean retired;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser retiredBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+
+    private String retireComments;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public WebUser getOwner() { return owner; }
+    public void setOwner(WebUser owner) { this.owner = owner; }
+
+    public String getEncryptedKey() { return encryptedKey; }
+    public void setEncryptedKey(String encryptedKey) { this.encryptedKey = encryptedKey; }
+
+    public String getLast4() { return last4; }
+    public void setLast4(String last4) { this.last4 = last4; }
+
+    public String getModelOverride() { return modelOverride; }
+    public void setModelOverride(String modelOverride) { this.modelOverride = modelOverride; }
+
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+
+    public WebUser getCreatedBy() { return createdBy; }
+    public void setCreatedBy(WebUser createdBy) { this.createdBy = createdBy; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public boolean isRetired() { return retired; }
+    public void setRetired(boolean retired) { this.retired = retired; }
+
+    public WebUser getRetiredBy() { return retiredBy; }
+    public void setRetiredBy(WebUser retiredBy) { this.retiredBy = retiredBy; }
+
+    public Date getRetiredAt() { return retiredAt; }
+    public void setRetiredAt(Date retiredAt) { this.retiredAt = retiredAt; }
+
+    public String getRetireComments() { return retireComments; }
+    public void setRetireComments(String retireComments) { this.retireComments = retireComments; }
+
+}

--- a/src/main/java/lk/gov/health/phsp/enums/LetterImportItemStatus.java
+++ b/src/main/java/lk/gov/health/phsp/enums/LetterImportItemStatus.java
@@ -1,0 +1,29 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.enums;
+
+/**
+ * Review state of a single detected letter within a batch.
+ */
+public enum LetterImportItemStatus {
+
+    /** Awaiting the reviewer's decision. */
+    PENDING("Pending"),
+    /** Accepted; a Document (letter) was created from it. */
+    ACCEPTED("Accepted"),
+    /** Discarded by the reviewer; no letter created. */
+    DISCARDED("Discarded");
+
+    private final String label;
+
+    LetterImportItemStatus(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/enums/LetterImportStatus.java
+++ b/src/main/java/lk/gov/health/phsp/enums/LetterImportStatus.java
@@ -1,0 +1,33 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.enums;
+
+/**
+ * Lifecycle of a {@code LetterImportBatch} (an uploaded multi-letter PDF).
+ */
+public enum LetterImportStatus {
+
+    /** Uploaded, not yet processed. */
+    NEW("New"),
+    /** Being split and OCR'd by Claude. */
+    PROCESSING("Processing"),
+    /** Processing complete; items are ready for review. */
+    READY("Ready for review"),
+    /** Processing failed; see the batch error message. */
+    FAILED("Failed"),
+    /** All items have been accepted or discarded. */
+    DONE("Done");
+
+    private final String label;
+
+    LetterImportStatus(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/enums/Privilege.java
+++ b/src/main/java/lk/gov/health/phsp/enums/Privilege.java
@@ -33,6 +33,7 @@ public enum Privilege {
     Search_Letter("Search Letter"),
     Add_Actions_To_Letter("Add Actions"),
     Remove_Actions_To_Letter("Remove Actions"),
+    Import_Letters("Import Letters from PDF"),
     //Mail Branch Mail Management
     Add_Letter_Postal_Branch("Add Letter"),
     Edit_Letter_Postal_Branch("Edit Letter"),

--- a/src/main/java/lk/gov/health/phsp/facade/LetterImportBatchFacade.java
+++ b/src/main/java/lk/gov/health/phsp/facade/LetterImportBatchFacade.java
@@ -1,0 +1,28 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.facade;
+
+import lk.gov.health.phsp.entity.LetterImportBatch;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class LetterImportBatchFacade extends AbstractFacade<LetterImportBatch> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public LetterImportBatchFacade() {
+        super(LetterImportBatch.class);
+    }
+
+}

--- a/src/main/java/lk/gov/health/phsp/facade/LetterImportItemFacade.java
+++ b/src/main/java/lk/gov/health/phsp/facade/LetterImportItemFacade.java
@@ -1,0 +1,28 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.facade;
+
+import lk.gov.health.phsp.entity.LetterImportItem;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class LetterImportItemFacade extends AbstractFacade<LetterImportItem> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public LetterImportItemFacade() {
+        super(LetterImportItem.class);
+    }
+
+}

--- a/src/main/java/lk/gov/health/phsp/facade/UserClaudeApiKeyFacade.java
+++ b/src/main/java/lk/gov/health/phsp/facade/UserClaudeApiKeyFacade.java
@@ -1,0 +1,28 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.facade;
+
+import lk.gov.health.phsp.entity.UserClaudeApiKey;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class UserClaudeApiKeyFacade extends AbstractFacade<UserClaudeApiKey> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public UserClaudeApiKeyFacade() {
+        super(UserClaudeApiKey.class);
+    }
+
+}

--- a/src/main/java/lk/gov/health/phsp/pojcs/AnthropicResponse.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/AnthropicResponse.java
@@ -1,0 +1,39 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+
+/**
+ * Result of a call to the Anthropic Messages API: the final assistant text plus
+ * the accumulated token usage across any agentic tool-use iterations.
+ */
+public class AnthropicResponse implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String content;
+    private final long inputTokens;
+    private final long outputTokens;
+
+    public AnthropicResponse(String content, long inputTokens, long outputTokens) {
+        this.content = content;
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public long getInputTokens() {
+        return inputTokens;
+    }
+
+    public long getOutputTokens() {
+        return outputTokens;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/pojcs/LetterExtractionResult.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/LetterExtractionResult.java
@@ -1,0 +1,79 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+
+/**
+ * Structured metadata extracted by Claude from a single letter (one PDF
+ * segment) for the letter-import review step. Identifier fields are populated
+ * only when Claude could resolve the printed name to a real DMIS entity via the
+ * grounding tools; otherwise the free-text name is kept for the reviewer.
+ */
+public class LetterExtractionResult implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String subject;
+    /** Letter date as printed, ISO yyyy-MM-dd when parseable, else null. */
+    private String letterDate;
+    private String senderInstitutionName;
+    private Long resolvedInstitutionId;
+    private String senderName;
+    private Long resolvedStaffId;
+    private String registrationNo;
+    private String referenceNo;
+    /** Claude's self-reported confidence, 0..1. */
+    private double confidence;
+
+    /** The raw JSON returned by Claude, kept for auditing/debugging. */
+    private String rawJson;
+    private long inputTokens;
+    private long outputTokens;
+    /** Non-null if extraction failed; the reviewer then fills fields manually. */
+    private String errorMessage;
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+
+    public String getLetterDate() { return letterDate; }
+    public void setLetterDate(String letterDate) { this.letterDate = letterDate; }
+
+    public String getSenderInstitutionName() { return senderInstitutionName; }
+    public void setSenderInstitutionName(String senderInstitutionName) { this.senderInstitutionName = senderInstitutionName; }
+
+    public Long getResolvedInstitutionId() { return resolvedInstitutionId; }
+    public void setResolvedInstitutionId(Long resolvedInstitutionId) { this.resolvedInstitutionId = resolvedInstitutionId; }
+
+    public String getSenderName() { return senderName; }
+    public void setSenderName(String senderName) { this.senderName = senderName; }
+
+    public Long getResolvedStaffId() { return resolvedStaffId; }
+    public void setResolvedStaffId(Long resolvedStaffId) { this.resolvedStaffId = resolvedStaffId; }
+
+    public String getRegistrationNo() { return registrationNo; }
+    public void setRegistrationNo(String registrationNo) { this.registrationNo = registrationNo; }
+
+    public String getReferenceNo() { return referenceNo; }
+    public void setReferenceNo(String referenceNo) { this.referenceNo = referenceNo; }
+
+    public double getConfidence() { return confidence; }
+    public void setConfidence(double confidence) { this.confidence = confidence; }
+
+    public String getRawJson() { return rawJson; }
+    public void setRawJson(String rawJson) { this.rawJson = rawJson; }
+
+    public long getInputTokens() { return inputTokens; }
+    public void setInputTokens(long inputTokens) { this.inputTokens = inputTokens; }
+
+    public long getOutputTokens() { return outputTokens; }
+    public void setOutputTokens(long outputTokens) { this.outputTokens = outputTokens; }
+
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
+    public boolean isFailed() { return errorMessage != null; }
+}

--- a/src/main/java/lk/gov/health/phsp/pojcs/PageRange.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/PageRange.java
@@ -1,0 +1,59 @@
+/*
+ * DMIS - Document Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+
+/**
+ * A contiguous range of pages within a PDF that represents a single letter,
+ * produced by {@code PdfSplitService.detectSegments}.
+ *
+ * <p>Page indices are <strong>zero-based and inclusive</strong>:
+ * {@code start} is the first page of the letter, {@code end} is the last.</p>
+ */
+public class PageRange implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int start;
+    private int end;
+
+    public PageRange() {
+    }
+
+    public PageRange(int start, int end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /** Zero-based index of the first page (inclusive). */
+    public int getStart() {
+        return start;
+    }
+
+    public void setStart(int start) {
+        this.start = start;
+    }
+
+    /** Zero-based index of the last page (inclusive). */
+    public int getEnd() {
+        return end;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    /** Number of pages in this letter (always >= 1 for a valid range). */
+    public int getPageCount() {
+        return (end - start) + 1;
+    }
+
+    @Override
+    public String toString() {
+        return "PageRange{" + start + ".." + end + " (" + getPageCount() + " pages)}";
+    }
+}

--- a/src/main/webapp/change_my_claude_api_key.xhtml
+++ b/src/main/webapp/change_my_claude_api_key.xhtml
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <body>
+        <ui:composition template="./template1.xhtml">
+            <ui:define name="content">
+                <h:form>
+                    <p:panelGrid columns="2" columnClasses="alignLeft alignLeft" class="pageCenter bg-white border border-light">
+
+                        <f:facet name="header">
+                            <div class="fs-5 fw-bold my-2">My Claude API Key</div>
+                        </f:facet>
+
+                        <h:outputLabel value="Current Key" class="fs-6 fw-bold" />
+                        <h:outputText value="#{claudeApiKeyController.maskedKey}" />
+
+                        <h:outputLabel value="New Claude API Key" class="fs-6 fw-bold" />
+                        <p:inputText class="form-control" id="rawKey" autocomplete="off"
+                                     value="#{claudeApiKeyController.rawKeyInput}"
+                                     placeholder="sk-ant-..." />
+
+                        <h:outputLabel value="Model (optional)" class="fs-6 fw-bold" />
+                        <p:inputText class="form-control" id="modelOverride" autocomplete="off"
+                                     value="#{claudeApiKeyController.modelOverride}"
+                                     placeholder="leave blank to use the system default" />
+
+                        <p:spacer />
+                        <h:panelGroup>
+                            <h:commandButton class="my-2 me-2 btn btn-success"
+                                             action="#{claudeApiKeyController.saveKey()}"
+                                             value="Save Key" />
+                            <h:commandButton class="my-2 btn btn-outline-danger"
+                                             action="#{claudeApiKeyController.removeKey()}"
+                                             rendered="#{claudeApiKeyController.keyConfigured}"
+                                             value="Remove Key" />
+                        </h:panelGroup>
+                    </p:panelGrid>
+
+                    <div class="pageCenter text-muted small mt-3">
+                        Your key is stored encrypted and is used only to process your own letter
+                        imports. It is never shown again after saving and is billed to your own
+                        Anthropic account. Get a key at
+                        <h:outputLink value="https://console.anthropic.com/settings/keys" target="_blank">
+                            console.anthropic.com</h:outputLink>.
+                    </div>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </body>
+</html>

--- a/src/main/webapp/document/letter_import.xhtml
+++ b/src/main/webapp/document/letter_import.xhtml
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <body>
+        <ui:composition template="/template1.xhtml">
+            <ui:define name="content">
+
+                <h:form id="importForm" enctype="multipart/form-data">
+                    <p:growl id="msgs" showDetail="true" />
+
+                    <div class="pageCenter bg-white border border-light p-3">
+                        <div class="fs-5 fw-bold my-2">Import Letters from a PDF</div>
+                        <p class="text-muted small">
+                            Upload a single PDF containing several letters separated by blank pages.
+                            Each letter is OCR'd with your own Claude API key, then proposed for your review.
+                        </p>
+
+                        <!-- 1. Upload -->
+                        <h:panelGroup id="uploadPanel" layout="block"
+                                      rendered="#{empty letterImportController.batch}">
+                            <p:fileUpload listener="#{letterImportController.handleUpload}"
+                                          mode="advanced" auto="true" dragDropSupport="true"
+                                          accept=".pdf" sizeLimit="52428800"
+                                          label="Choose PDF" update="importForm" />
+                            <h:commandButton class="btn btn-success my-2"
+                                             action="#{letterImportController.startImport}"
+                                             value="Start Processing" />
+                        </h:panelGroup>
+
+                        <!-- 2. Processing -->
+                        <h:panelGroup id="processingPanel" layout="block"
+                                      rendered="#{letterImportController.processing}">
+                            <div class="my-2">Processing #{letterImportController.batch.originalFileName} …</div>
+                            <p:progressBar value="#{letterImportController.progressPercent}" labelTemplate="{value}%"
+                                           style="height:20px" />
+                            <div class="text-muted small my-1">
+                                #{letterImportController.batch.processedCount} of
+                                #{letterImportController.batch.letterCount} letters recognised
+                            </div>
+                            <p:poll interval="3" listener="#{letterImportController.refreshStatus}"
+                                    update="importForm" autoStart="true" />
+                        </h:panelGroup>
+
+                        <!-- failure -->
+                        <h:panelGroup layout="block" rendered="#{letterImportController.failed}">
+                            <div class="alert alert-danger my-2">
+                                Processing failed: #{letterImportController.batch.errorMessage}
+                            </div>
+                            <h:commandButton class="btn btn-secondary"
+                                             action="#{letterImportController.toLetterImport}"
+                                             value="Start over" />
+                        </h:panelGroup>
+                    </div>
+
+                    <!-- 3. Review wizard -->
+                    <h:panelGroup id="reviewPanel" layout="block"
+                                  rendered="#{not empty letterImportController.items}">
+                        <div class="pageCenter bg-white border border-light p-3 mt-3">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <div class="fw-bold">
+                                    Letter #{letterImportController.currentIndex + 1} of #{letterImportController.itemCount}
+                                </div>
+                                <div class="text-muted small">
+                                    #{letterImportController.acceptedCount} accepted ·
+                                    #{letterImportController.pendingCount} pending
+                                </div>
+                            </div>
+
+                            <h:panelGroup rendered="#{not empty letterImportController.currentItem}">
+                                <div class="row">
+                                    <!-- preview -->
+                                    <div class="col-6">
+                                        <h:graphicImage value="#{letterImportController.currentPreviewDataUri}"
+                                                        style="max-width:100%;border:1px solid #ddd" />
+                                        <div class="text-muted small mt-1">
+                                            Pages #{letterImportController.currentItem.startPage + 1}–#{letterImportController.currentItem.endPage + 1}
+                                            · status: #{letterImportController.currentItem.status}
+                                            <h:outputText value=" · confidence: #{letterImportController.currentItem.confidence}"
+                                                          rendered="#{not empty letterImportController.currentItem.confidence}" />
+                                        </div>
+                                        <h:panelGroup rendered="#{not empty letterImportController.currentItem.errorMessage}">
+                                            <div class="alert alert-warning small mt-2">
+                                                #{letterImportController.currentItem.errorMessage}
+                                            </div>
+                                        </h:panelGroup>
+                                    </div>
+
+                                    <!-- editable proposal -->
+                                    <div class="col-6">
+                                        <p:panelGrid columns="2" layout="grid"
+                                                     columnClasses="ui-grid-col-4,ui-grid-col-8">
+                                            <p:outputLabel value="Subject" />
+                                            <p:inputText class="form-control"
+                                                         value="#{letterImportController.currentItem.subject}" />
+
+                                            <p:outputLabel value="Letter Date" />
+                                            <p:datePicker value="#{letterImportController.currentItem.letterDate}"
+                                                          pattern="yyyy-MM-dd" showIcon="true" />
+
+                                            <p:outputLabel value="Stamp / Received Date" />
+                                            <p:datePicker value="#{letterImportController.currentItem.receivedDate}"
+                                                          pattern="yyyy-MM-dd" showIcon="true" />
+
+                                            <p:outputLabel value="From Institution" />
+                                            <p:autoComplete value="#{letterImportController.currentItem.resolvedInstitution}"
+                                                            completeMethod="#{letterImportController.completeInstitution}"
+                                                            var="ins" itemLabel="#{ins.name}" itemValue="#{ins}"
+                                                            converter="nameableConverter1"
+                                                            forceSelection="true" minQueryLength="2"
+                                                            delay="400" cache="false" maxResults="20"
+                                                            class="form-control" />
+
+                                            <p:outputLabel value="Sender Name" />
+                                            <p:inputText class="form-control"
+                                                         value="#{letterImportController.currentItem.senderName}" />
+
+                                            <p:outputLabel value="Registration No" />
+                                            <p:inputText class="form-control"
+                                                         value="#{letterImportController.currentItem.registrationNo}" />
+
+                                            <p:outputLabel value="Reference No" />
+                                            <p:inputText class="form-control"
+                                                         value="#{letterImportController.currentItem.referenceNo}" />
+                                        </p:panelGrid>
+
+                                        <div class="mt-3">
+                                            <h:commandButton class="btn btn-success me-2"
+                                                             action="#{letterImportController.acceptCurrent}"
+                                                             value="Accept &amp; Create"
+                                                             disabled="#{letterImportController.currentItem.status == 'ACCEPTED'}">
+                                                <f:ajax execute="@form" render="@form" />
+                                            </h:commandButton>
+                                            <h:commandButton class="btn btn-outline-primary me-2"
+                                                             action="#{letterImportController.saveCurrentEdits}"
+                                                             value="Save Edits">
+                                                <f:ajax execute="@form" render="@form" />
+                                            </h:commandButton>
+                                            <h:commandButton class="btn btn-outline-danger me-2"
+                                                             action="#{letterImportController.discardCurrent}"
+                                                             value="Discard">
+                                                <f:ajax execute="@form" render="@form" />
+                                            </h:commandButton>
+                                        </div>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <div class="d-flex justify-content-between mt-3">
+                                <h:commandButton class="btn btn-secondary"
+                                                 action="#{letterImportController.previous}"
+                                                 value="Previous" disabled="#{not letterImportController.hasPrevious}">
+                                    <f:ajax execute="@form" render="@form" />
+                                </h:commandButton>
+                                <h:commandButton class="btn btn-secondary"
+                                                 action="#{letterImportController.skipCurrent}"
+                                                 value="Skip / Next" disabled="#{not letterImportController.hasNext}">
+                                    <f:ajax execute="@form" render="@form" />
+                                </h:commandButton>
+                            </div>
+                        </div>
+                    </h:panelGroup>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </body>
+</html>

--- a/src/main/webapp/resources/ezcomp/header.xhtml
+++ b/src/main/webapp/resources/ezcomp/header.xhtml
@@ -50,6 +50,9 @@
                                         <h:commandButton action="#{webUserController.toChangeMyUsername()}"
                                                          class="dropdown-item" value="Change My Username">
                                         </h:commandButton>
+                                        <h:commandButton action="#{claudeApiKeyController.toManageMyClaudeApiKey()}"
+                                                         class="dropdown-item" value="My Claude API Key">
+                                        </h:commandButton>
                                         <h:commandButton action="#{webUserController.toChangeLoggedInstitution()}"
                                                          class="dropdown-item" value="Change Logged Institute">
                                         </h:commandButton>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -49,6 +49,9 @@
                                 action="#{menuController.toLetterGenerateNew()}"  />
                     <p:menuitem class="submenu-item" ajax="false" value="New Internal Memo" action="#{menuController.toLetterAddNewReceivedLetter()}"  />
                     <p:menuitem class="submenu-item" ajax="false" value="Letter Creation Registry" action="#{letterController.toAcceptCopyForwardedLettersToMe()}" />
+                    <p:menuitem class="submenu-item" ajax="false" value="Import Letters from PDF"
+                                action="#{letterImportController.toLetterImport()}"
+                                rendered="#{webUserController.hasPrivilege('Import_Letters')}" />
                 </p:submenu>
 
 


### PR DESCRIPTION
Closes #119. Final part of the user-keyed Claude letter-import feature (`docs/letter-import-plan.md`).

## What (new in this PR)
- **LetterImportConfig** — model, blank threshold, render DPI, max pages, retention days resolved from system property → env var → default (DMIS has no ConfigOption store).
- **LetterImportCleanupBean** — `@Singleton @Schedule` (every 6 h) purges batches/items (and their PDF/preview blobs) older than the retention window.
- Wires config into **LetterImportService** (default model, blank threshold, render DPI, and a **max-pages guard** that fails oversized PDFs early) and **LetterImportController** (default model).
- **docs/letter-import.md** — setup, operator configuration, workflow, data lifecycle.

## Stacked PR — contains the whole feature
This branch sits on top of #120–#124, so it is effectively the **full integration branch**: building it compiles all six parts at once. Recommended: check this branch out, build/verify once, then merge in order **#120 → #121 → #122 → #123 → #124 → #125**.

## Operator note
Set `DMIS_CRYPTO_SECRET` (or `-Ddmis.crypto.secret`) in production so stored Claude keys are not recoverable with the default passphrase.

## Testing
Build performed by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)