### PR TITLE
@

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/WebUserApplicationController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserApplicationController.java
@@ -118,6 +118,7 @@ public class WebUserApplicationController {
         new PrivilegeTreeNode("Search Letter", institutionalMailManagement, Privilege.Search_Letter);
         new PrivilegeTreeNode("Add Actions", institutionalMailManagement, Privilege.Add_Actions_To_Letter);
         new PrivilegeTreeNode("Remove Actions", institutionalMailManagement, Privilege.Remove_Actions_To_Letter);
+        new PrivilegeTreeNode("Import Letters from PDF", institutionalMailManagement, Privilege.Import_Letters);
 
         //Mail Branch Mail Management
         new PrivilegeTreeNode("Add Letter", mailBranchMailManagement, Privilege.Add_Letter_Postal_Branch);
@@ -250,6 +251,7 @@ public class WebUserApplicationController {
         new PrivilegeTreeNode("Search Letter", institutionalMailManagement, Privilege.Search_Letter);
         new PrivilegeTreeNode("Add Actions", institutionalMailManagement, Privilege.Add_Actions_To_Letter);
         new PrivilegeTreeNode("Remove Actions", institutionalMailManagement, Privilege.Remove_Actions_To_Letter);
+        new PrivilegeTreeNode("Import Letters from PDF", institutionalMailManagement, Privilege.Import_Letters);
 
         //Institution Administration
         new PrivilegeTreeNode("Manage Institution Users", institutionAdministration, Privilege.Manage_Institution_Users);


### PR DESCRIPTION
Register Import_Letters in the privilege assignment tree (#118)

The new Import_Letters privilege gated the import menu item but was never added to the PrivilegeTreeNode tree, so it could not be granted through the user admin UI (and was skipped by "grant all"), leaving the menu hidden. Add it under Institutional Mail Management in both the master assignable tree and the hospital role-default template.



@