### PR TITLE
Fix letters missing from Letter Copy/Forward Register (unit-letter forwards)

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/LetterController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/LetterController.java
@@ -1740,6 +1740,7 @@ public class LetterController implements Serializable {
         docHx.setHistoryType(HistoryType.Letter_Copy_or_Forward);
         docHx.setDocument(selected);
         docHx.setFromUser(selected.getCurrentOwner());
+        docHx.setFromInstitution(webUserController.getLoggedInstitution());
         docHx.setToInsOrUser(webUserCopy);
         docHx.setComments(comments);
         docHx.setItem(minute);
@@ -1804,6 +1805,7 @@ public class LetterController implements Serializable {
         docHx.setHistoryType(HistoryType.Letter_Copy_or_Forward);
         docHx.setDocument(selected);
         docHx.setFromUser(selected.getCurrentOwner());
+        docHx.setFromInstitution(webUserController.getLoggedInstitution());
         docHx.setToInsOrUser(webUserCopy);
         docHx.setComments(comments);
         docHx.setItem(minute);


### PR DESCRIPTION
## Problem

Users (The Office of the Secretary) reported that letters forwarded today were missing from the **Letter Copy / Forward Register** (`letter_copy_forward_register.xhtml`). For example, 9 letters were forwarded to CFO III but only **1** appeared.

## Root cause

The register query (`LetterController.fillForwardCopyActions`) filters:

```
and h.fromInstitution = :loggedInstitution
```

Two copy/forward paths used by the **unit-letter view** never set `fromInstitution` (only `institution`):

- `forwardOrCopyToForUnitLetter()`
- `forwardOrCopyToAndNewUnitLetter()` — bound to the **"Send & New"** button on `unit_letter_view.xhtml`

Letters forwarded via "Send & New" were therefore written with `fromInstitution = NULL` and silently excluded from the register. The letters themselves were saved correctly and remain visible to recipients in their received registers — only the sender-side register was affected. Forwards made via the plain **"Send"** button (`forwardOrCopyTo` / `forwardOrCopyToAndNew`) were unaffected because those already set `fromInstitution`.

Confirmed against production: of 162 `Letter_Copy_or_Forward` rows created today, 106 had `fromInstitution = NULL`, all belonging to the reporting office.

## Fix

Set `fromInstitution` to the logged institution in both unit-letter methods, mirroring the working `forwardOrCopyTo()`:

```java
docHx.setFromInstitution(webUserController.getLoggedInstitution());
```

## Note on existing data

Today's affected rows on production were already backfilled (setting `FROMINSTITUTION_ID = INSTITUTION_ID` for today's `Letter_Copy_or_Forward` rows where `FROMINSTITUTION_ID` was NULL), restoring the register immediately. Older historical NULL rows were left untouched. This PR prevents recurrence.

## Testing

- [ ] Forward a letter via the "Send & New" button on the unit-letter view, then confirm it appears in the Letter Copy / Forward Register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
