### PR TITLE
fix(persistence): disable EclipseLink schema generation against production DB

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -11,7 +11,7 @@
       <!--            <property name="eclipselink.logging.level.sql" value="FINE"/>
             <property name="eclipselink.logging.parameters" value="true"/>-->
       <!-- DISABLED while pointed at production: do not let EclipseLink ALTER prod schema -->
-       <property name="javax.persistence.schema-generation.database.action" value="create-or-extend-tables"/> 
+      <!--<property name="javax.persistence.schema-generation.database.action" value="create-or-extend-tables"/>-->
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
## Summary
- Comments out `javax.persistence.schema-generation.database.action` (`create-or-extend-tables`) in `persistence.xml`. The comment above the property said it was disabled while pointed at production, but the property was still active.
- With it active, every deployment made EclipseLink issue DDL (ALTER TABLE / ADD CONSTRAINT) against the live `dmis` MySQL database — producing 18 `Duplicate foreign key constraint` errors (MySQL 1826) per deploy and taking metadata locks / implicit commits on production tables.

Fixes #137

## Test plan
- Redeploy the WAR and confirm the Payara server log no longer shows `Duplicate foreign key constraint` / Error Code 1826 entries during deployment.
- Confirm the application still starts and queries normally (no schema changes are needed by the current build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)