### PR TITLE
fix: clear assigned staff and add filter to Assign To dropdown (#144)

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/LetterController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/LetterController.java
@@ -1652,6 +1652,7 @@ public class LetterController implements Serializable {
         selected.setCompleted(false);
         documentFacade.edit(selected);
 
+        webUser = null;
         comments = "";
 
         JsfUtil.addSuccessMessage("Letter assigned successfully");

--- a/src/main/webapp/document/unit_letter_view.xhtml
+++ b/src/main/webapp/document/unit_letter_view.xhtml
@@ -307,9 +307,11 @@
                                     Assign to
                                 </f:facet>
                                 <h:outputLabel class="fs-6" value="Assign To:"></h:outputLabel>
-                                <p:selectOneMenu 
-                                    value="#{letterController.webUser}" 
-                                    class="form-control">
+                                <p:selectOneMenu
+                                    value="#{letterController.webUser}"
+                                    class="form-control"
+                                    filter="true"
+                                    filterMatchMode="contains">
                                     <f:selectItem itemLabel="Select" ></f:selectItem>
                                     <f:selectItems value="#{webUserController.usersForMyInstitute}" var="u"
                                                    itemLabel="#{u.person.name}" itemValue="#{u}"></f:selectItems>


### PR DESCRIPTION
## Summary
Fixes the *Assign to* panel on `app/document/unit_letter_view.xhtml`.

- **Selected staff now clears after assigning.** `LetterController.assignTo()` reset `comments` but never cleared `webUser`, so the dropdown kept the previously assigned person — requiring a manual reset and making accidental re-assignment easy. It now sets `webUser = null` after a successful assign, matching how `forwardOrCopyTo()` handles `webUserCopy`.
- **Assign To dropdown is now searchable.** Added `filter="true" filterMatchMode="contains"` to the `p:selectOneMenu`, so staff can be found by typing instead of scrolling a long list.

## Testing
JSF/PrimeFaces change — to be verified by the maintainer in the running app (per project preference, no local build run).

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)