### PR TITLE
fix: upgrade PrimeFaces to 14.0.0 and fix incompatible API usages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
-            <version>10.0.0</version>
+            <version>14.0.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>org.primefaces.extensions</groupId>
             <artifactId>primefaces-extensions</artifactId>
-            <version>15.0.15</version>
+            <version>14.0.0</version>
         </dependency>
 
         <!-- JWT dependancy. Pin to 5.3.0; 6.x is compiled against Java 17

--- a/src/main/java/lk/gov/health/phsp/bean/DashboardController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/DashboardController.java
@@ -516,7 +516,7 @@ public class DashboardController implements Serializable {
         dataSet.setBorderColor("rgb(9, 132, 227)");
         dataSet.setBorderWidth(1);
 
-        List<Number> values = new ArrayList<>();
+        List<Object> values = new ArrayList<>();
         List<String> labels = new ArrayList<>();
 
         List<Object[]> topInstitutions = letterController.getTopInstitutionsByLetterCount(10, fd, td);
@@ -566,8 +566,8 @@ public class DashboardController implements Serializable {
         pendingDataSet.setBorderColor("rgb(253, 203, 110)");
         pendingDataSet.setBorderWidth(1);
 
-        List<Number> acceptedValues = new ArrayList<>();
-        List<Number> pendingValues = new ArrayList<>();
+        List<Object> acceptedValues = new ArrayList<>();
+        List<Object> pendingValues = new ArrayList<>();
         List<String> labels = new ArrayList<>();
 
         List<Object[]> topInstitutions = letterController.getTopInstitutionsByCopyForwards(1000, fd, td);
@@ -696,8 +696,8 @@ public class DashboardController implements Serializable {
         pendingDataSet.setBorderColor("rgb(253, 203, 110)");
         pendingDataSet.setBorderWidth(1);
 
-        List<Number> acceptedValues = new ArrayList<>();
-        List<Number> pendingValues = new ArrayList<>();
+        List<Object> acceptedValues = new ArrayList<>();
+        List<Object> pendingValues = new ArrayList<>();
         List<String> labels = new ArrayList<>();
 
         List<Object[]> topInstitutions = letterController.getTopInstitutionsCopyForwardsSentByMyInstitution(10);

--- a/src/main/java/lk/gov/health/phsp/bean/WebUserApplicationController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserApplicationController.java
@@ -55,12 +55,12 @@ public class WebUserApplicationController {
     private UserTransactionController userTransactionController;
     private volatile List<WebUser> items = null;
 
-    private TreeNode allPrivilegeRoot;
-    private TreeNode hospitalPrivilegeRoot;
-    private TreeNode labPrivilegeRoot;
-    private TreeNode provincialPrivilegeRoot;
-    private TreeNode regionalPrivilegeRoot;
-    private TreeNode mohPrivilegeRoot;
+    private TreeNode<Object> allPrivilegeRoot;
+    private TreeNode<Object> hospitalPrivilegeRoot;
+    private TreeNode<Object> labPrivilegeRoot;
+    private TreeNode<Object> provincialPrivilegeRoot;
+    private TreeNode<Object> regionalPrivilegeRoot;
+    private TreeNode<Object> mohPrivilegeRoot;
 
     /**
      * Creates a new instance of WebUserApplicationController
@@ -365,42 +365,42 @@ public class WebUserApplicationController {
         items = null;
     }
 
-    public TreeNode getAllPrivilegeRoot() {
+    public TreeNode<Object> getAllPrivilegeRoot() {
         if (allPrivilegeRoot == null) {
             createAllPrivilege();
         }
         return allPrivilegeRoot;
     }
 
-    public TreeNode getHospitalPrivilegeRoot() {
+    public TreeNode<Object> getHospitalPrivilegeRoot() {
         if (hospitalPrivilegeRoot == null) {
             createHospitalPrivilege();
         }
         return hospitalPrivilegeRoot;
     }
 
-    public TreeNode getLabPrivilegeRoot() {
+    public TreeNode<Object> getLabPrivilegeRoot() {
         if (labPrivilegeRoot == null) {
             createLabPrivilege();
         }
         return labPrivilegeRoot;
     }
 
-    public TreeNode getProvincialPrivilegeRoot() {
+    public TreeNode<Object> getProvincialPrivilegeRoot() {
         if (provincialPrivilegeRoot == null) {
             createProvincialPrivilege();
         }
         return provincialPrivilegeRoot;
     }
 
-    public TreeNode getRegionalPrivilegeRoot() {
+    public TreeNode<Object> getRegionalPrivilegeRoot() {
         if (regionalPrivilegeRoot == null) {
             createRegionalPrivilege();
         }
         return regionalPrivilegeRoot;
     }
 
-    public TreeNode getMohPrivilegeRoot() {
+    public TreeNode<Object> getMohPrivilegeRoot() {
         return mohPrivilegeRoot;
     }
 

--- a/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
@@ -178,10 +178,12 @@ public class WebUserController implements Serializable {
      * Privileges
      *
      */
-    private TreeNode allPrivilegeRoot;
-    private TreeNode myPrivilegeRoot;
-    private TreeNode[] selectedNodes;
-    private TreeNode[] selectedNodeSet;
+    private TreeNode<Object> allPrivilegeRoot;
+    private TreeNode<Object> myPrivilegeRoot;
+    @SuppressWarnings("unchecked")
+    private TreeNode<Object>[] selectedNodes = new TreeNode[0];
+    @SuppressWarnings("unchecked")
+    private TreeNode<Object>[] selectedNodeSet = new TreeNode[0];
 
     private InstitutionType institutionType;
 
@@ -358,11 +360,11 @@ public class WebUserController implements Serializable {
         String j = "select u from WebUser u where u.retired=false";
         items = getFacade().findByJpql(j);
 
-        for (TreeNode n : getAllPrivilegeRoot().getChildren()) {
+        for (TreeNode<Object> n : getAllPrivilegeRoot().getChildren()) {
             n.setSelected(false);
-            for (TreeNode n1 : n.getChildren()) {
+            for (TreeNode<Object> n1 : n.getChildren()) {
                 n1.setSelected(false);
-                for (TreeNode n2 : n1.getChildren()) {
+                for (TreeNode<Object> n2 : n1.getChildren()) {
                     n2.setSelected(false);
                 }
             }
@@ -500,7 +502,7 @@ public class WebUserController implements Serializable {
         return url;
     }
 
-    public void preparePrivileges(TreeNode allPrevs) {
+    public void preparePrivileges(TreeNode<Object> allPrevs) {
         if (current == null) {
             JsfUtil.addErrorMessage("Nothing Selected");
             return;
@@ -512,33 +514,33 @@ public class WebUserController implements Serializable {
         selectedNodes = new TreeNode[0];
         List<UserPrivilege> userps = userPrivilegeList(current);
 
-        for (TreeNode n : allPrevs.getChildren()) {
+        for (TreeNode<Object> n : allPrevs.getChildren()) {
             n.setSelected(false);
-            for (TreeNode n1 : n.getChildren()) {
+            for (TreeNode<Object> n1 : n.getChildren()) {
                 n1.setSelected(false);
-                for (TreeNode n2 : n1.getChildren()) {
+                for (TreeNode<Object> n2 : n1.getChildren()) {
                     n2.setSelected(false);
                 }
             }
         }
-        List<TreeNode> temSelected = new ArrayList<>();
+        List<TreeNode<Object>> temSelected = new ArrayList<>();
         for (UserPrivilege wup : userps) {
             if (wup.getPrivilege() == null) {
                 continue;
             }
-            for (TreeNode n : allPrevs.getChildren()) {
+            for (TreeNode<Object> n : allPrevs.getChildren()) {
                 if (wup.getPrivilege().equals(((PrivilegeTreeNode) n).getP())) {
                     n.setSelected(true);
 
                     temSelected.add(n);
                 }
-                for (TreeNode n1 : n.getChildren()) {
+                for (TreeNode<Object> n1 : n.getChildren()) {
                     if (wup.getPrivilege().equals(((PrivilegeTreeNode) n1).getP())) {
                         n1.setSelected(true);
 
                         temSelected.add(n1);
                     }
-                    for (TreeNode n2 : n1.getChildren()) {
+                    for (TreeNode<Object> n2 : n1.getChildren()) {
                         if (wup.getPrivilege().equals(((PrivilegeTreeNode) n2).getP())) {
                             n2.setSelected(true);
 
@@ -560,33 +562,33 @@ public class WebUserController implements Serializable {
         selectedNodes = new TreeNode[0];
         List<UserPrivilege> userps = userPrivilegeList(current);
 
-        for (TreeNode n : getAllPrivilegeRoot().getChildren()) {
+        for (TreeNode<Object> n : getAllPrivilegeRoot().getChildren()) {
             n.setSelected(false);
-            for (TreeNode n1 : n.getChildren()) {
+            for (TreeNode<Object> n1 : n.getChildren()) {
                 n1.setSelected(false);
-                for (TreeNode n2 : n1.getChildren()) {
+                for (TreeNode<Object> n2 : n1.getChildren()) {
                     n2.setSelected(false);
                 }
             }
         }
-        List<TreeNode> temSelected = new ArrayList<>();
+        List<TreeNode<Object>> temSelected = new ArrayList<>();
         for (UserPrivilege wup : userps) {
             if (wup.getPrivilege() == null) {
                 continue;
             }
-            for (TreeNode n : getAllPrivilegeRoot().getChildren()) {
+            for (TreeNode<Object> n : getAllPrivilegeRoot().getChildren()) {
                 if (wup.getPrivilege().equals(((PrivilegeTreeNode) n).getP())) {
                     n.setSelected(true);
 
                     temSelected.add(n);
                 }
-                for (TreeNode n1 : n.getChildren()) {
+                for (TreeNode<Object> n1 : n.getChildren()) {
                     if (wup.getPrivilege().equals(((PrivilegeTreeNode) n1).getP())) {
                         n1.setSelected(true);
 
                         temSelected.add(n1);
                     }
-                    for (TreeNode n2 : n1.getChildren()) {
+                    for (TreeNode<Object> n2 : n1.getChildren()) {
                         if (wup.getPrivilege().equals(((PrivilegeTreeNode) n2).getP())) {
                             n2.setSelected(true);
 
@@ -608,33 +610,33 @@ public class WebUserController implements Serializable {
         selectedNodes = new TreeNode[0];
         List<UserPrivilege> userps = userPrivilegeList(current);
 
-        for (TreeNode n : getAllPrivilegeRoot().getChildren()) {
+        for (TreeNode<Object> n : getAllPrivilegeRoot().getChildren()) {
             n.setSelected(false);
-            for (TreeNode n1 : n.getChildren()) {
+            for (TreeNode<Object> n1 : n.getChildren()) {
                 n1.setSelected(false);
-                for (TreeNode n2 : n1.getChildren()) {
+                for (TreeNode<Object> n2 : n1.getChildren()) {
                     n2.setSelected(false);
                 }
             }
         }
-        List<TreeNode> temSelected = new ArrayList<>();
+        List<TreeNode<Object>> temSelected = new ArrayList<>();
         for (UserPrivilege wup : userps) {
             if (wup.getPrivilege() == null) {
                 continue;
             }
-            for (TreeNode n : getAllPrivilegeRoot().getChildren()) {
+            for (TreeNode<Object> n : getAllPrivilegeRoot().getChildren()) {
                 if (wup.getPrivilege().equals(((PrivilegeTreeNode) n).getP())) {
                     n.setSelected(true);
 
                     temSelected.add(n);
                 }
-                for (TreeNode n1 : n.getChildren()) {
+                for (TreeNode<Object> n1 : n.getChildren()) {
                     if (wup.getPrivilege().equals(((PrivilegeTreeNode) n1).getP())) {
                         n1.setSelected(true);
 
                         temSelected.add(n1);
                     }
-                    for (TreeNode n2 : n1.getChildren()) {
+                    for (TreeNode<Object> n2 : n1.getChildren()) {
                         if (wup.getPrivilege().equals(((PrivilegeTreeNode) n2).getP())) {
                             n2.setSelected(true);
 
@@ -649,7 +651,7 @@ public class WebUserController implements Serializable {
         return "/insAdmin/user_privileges?faces-redirect=true";
     }
 
-    public void prepareManagePrivileges(TreeNode privilegeRoot) {
+    public void prepareManagePrivileges(TreeNode<Object> privilegeRoot) {
         if (current == null) {
             JsfUtil.addErrorMessage("Nothing Selected");
             return;
@@ -661,33 +663,33 @@ public class WebUserController implements Serializable {
         selectedNodes = new TreeNode[0];
         List<UserPrivilege> userps = userPrivilegeList(current);
 
-        for (TreeNode n : privilegeRoot.getChildren()) {
+        for (TreeNode<Object> n : privilegeRoot.getChildren()) {
             n.setSelected(false);
-            for (TreeNode n1 : n.getChildren()) {
+            for (TreeNode<Object> n1 : n.getChildren()) {
                 n1.setSelected(false);
-                for (TreeNode n2 : n1.getChildren()) {
+                for (TreeNode<Object> n2 : n1.getChildren()) {
                     n2.setSelected(false);
                 }
             }
         }
-        List<TreeNode> temSelected = new ArrayList<>();
+        List<TreeNode<Object>> temSelected = new ArrayList<>();
         for (UserPrivilege wup : userps) {
             if (wup.getPrivilege() == null) {
                 continue;
             }
-            for (TreeNode n : privilegeRoot.getChildren()) {
+            for (TreeNode<Object> n : privilegeRoot.getChildren()) {
                 if (wup.getPrivilege().equals(((PrivilegeTreeNode) n).getP())) {
                     n.setSelected(true);
 
                     temSelected.add(n);
                 }
-                for (TreeNode n1 : n.getChildren()) {
+                for (TreeNode<Object> n1 : n.getChildren()) {
                     if (wup.getPrivilege().equals(((PrivilegeTreeNode) n1).getP())) {
                         n1.setSelected(true);
 
                         temSelected.add(n1);
                     }
-                    for (TreeNode n2 : n1.getChildren()) {
+                    for (TreeNode<Object> n2 : n1.getChildren()) {
                         if (wup.getPrivilege().equals(((PrivilegeTreeNode) n2).getP())) {
                             n2.setSelected(true);
 
@@ -2110,24 +2112,25 @@ public class WebUserController implements Serializable {
         this.selectedFundComments = selectedFundComments;
     }
 
-    public TreeNode getAllPrivilegeRoot() {
+    public TreeNode<Object> getAllPrivilegeRoot() {
         allPrivilegeRoot = webUserApplicationController.getAllPrivilegeRoot();
         return allPrivilegeRoot;
     }
 
-    public TreeNode[] getSelectedNodes() {
+    public TreeNode<Object>[] getSelectedNodes() {
         return selectedNodes;
     }
 
+    @SuppressWarnings("unchecked")
     public void setSelectedNodes(TreeNode[] selectedNodes) {
         this.selectedNodes = selectedNodes;
     }
 
-    public TreeNode getMyPrivilegeRoot() {
+    public TreeNode<Object> getMyPrivilegeRoot() {
         return myPrivilegeRoot;
     }
 
-    public void setMyPrivilegeRoot(TreeNode myPrivilegeRoot) {
+    public void setMyPrivilegeRoot(TreeNode<Object> myPrivilegeRoot) {
         this.myPrivilegeRoot = myPrivilegeRoot;
     }
 

--- a/src/main/java/lk/gov/health/phsp/enums/PrivilegeTreeNode.java
+++ b/src/main/java/lk/gov/health/phsp/enums/PrivilegeTreeNode.java
@@ -30,7 +30,8 @@ import org.primefaces.model.TreeNode;
  *
  * @author Dr M H B Ariyaratne<buddhika.ari@gmail.com>
  */
-public class PrivilegeTreeNode extends DefaultTreeNode {
+@SuppressWarnings("unchecked")
+public class PrivilegeTreeNode extends DefaultTreeNode<Object> {
 
     private Privilege p;
 


### PR DESCRIPTION
Closes #146

## Summary

- Bump `primefaces` from `10.0.0` → `14.0.0` and `primefaces-extensions` from `15.0.15` → `14.0.0` (extensions major version must always match PrimeFaces)
- Fix `TreeNode<T>` generification: propagate `TreeNode<Object>` through `PrivilegeTreeNode`, `WebUserApplicationController`, and `WebUserController` to resolve 27 compile errors
- Fix `DashboardController` chart methods: change `List<Number>` → `List<Object>` to match PF14's `DataSet.setData()` signature

## Test plan

- [ ] Application deploys without `NoSuchMethodError` on startup
- [ ] Privilege tree renders and checkbox selection works correctly
- [ ] Dashboard bar charts render without errors
- [ ] No regression on letter management, file management, and user administration flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)