### PR TITLE
chore: build on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,8 +322,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                     <compilerArguments>
                         <endorseddirs>${endorsed.dir}</endorseddirs>
                     </compilerArguments>

--- a/src/main/java/lk/gov/health/phsp/bean/LetterController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/LetterController.java
@@ -1,6 +1,5 @@
 package lk.gov.health.phsp.bean;
 
-import com.sun.jmx.remote.internal.ArrayQueue;
 import java.io.IOException;
 import java.io.InputStream;
 import lk.gov.health.phsp.entity.Document;


### PR DESCRIPTION
## Summary

Moves the build target to Java 11. This is the only genuinely unmerged work that was sitting on the stale `chore/java-11-build` branch, extracted cleanly on top of current `master`.

## Changes
- **pom.xml** — bump `maven-compiler-plugin` `source`/`target` from `1.8` to `11`.
- **LetterController.java** — remove the unused `import com.sun.jmx.remote.internal.ArrayQueue;`. This is an internal JDK API that does not exist on Java 11 and would break compilation; it was never referenced in the file.

## Notes
The old `chore/java-11-build` branch also carried an outdated copy of `docs/working-with-assigned-letters.md` (master already has the newer version via #150), so that was intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)